### PR TITLE
Change name to short.as

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: youyo/aws-cdk-github-actions@v2
         with:
           cdk_subcommand: 'deploy'
-          cdk_stack: '@(TinyMu-prod|Website-prod)'
+          cdk_stack: '@(Backend-prod|Website-prod)'
           cdk_args: '--require-approval never'
           working_dir: './packages/infra/'
           actions_comment: false

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -27,7 +27,7 @@ jobs:
         uses: youyo/aws-cdk-github-actions@v2
         with:
           cdk_subcommand: 'diff'
-          cdk_stack: '@(TinyMu-prod|Website-prod)'
+          cdk_stack: '@(Backend-prod|Website-prod)'
           working_dir: './packages/infra/'
           actions_comment: false
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tiny.mu",
+  "name": "short.as",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tiny.mu",
+      "name": "short.as",
       "version": "0.0.1",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tiny.mu",
+  "name": "short.as",
   "version": "0.0.1",
   "private": true,
   "workspaces": [

--- a/packages/infra/README.md
+++ b/packages/infra/README.md
@@ -8,5 +8,7 @@ First gain access to the account by either using `aws sso login`, or by copy/pas
 
 * `npm run build`: transpile the TypeScript to JavaScript
 * `npm run test`: execute the Jest unit and snapshot tests
-* `npx cdk diff TinyMu-dev`: compare the deployed dev stack with current state
-* `npx cdk deploy TinyMu-dev`: deploy the dev stack to the AWS account
+* `npx cdk list`: list the CDK stacks
+* `npx cdk diff Backend-dev`: compare the deployed dev stack with current state
+* `npx cdk deploy Backend-dev`: deploy the dev stack to the AWS account
+* `npx cdk deploy Website-dev`: deploy the website stack to the AWS account

--- a/packages/infra/bin/app.ts
+++ b/packages/infra/bin/app.ts
@@ -10,11 +10,11 @@ const REGION = 'eu-west-2';
 const app = new cdk.App();
 
 // Stacks used for development and testing
-const devBackend = new BackendStack(app, 'TinyMu-dev', { env: { account: ACCOUNT_ID, region: REGION } });
+const devBackend = new BackendStack(app, 'Backend-dev', { env: { account: ACCOUNT_ID, region: REGION } });
 const devWebsite = new WebsiteStack(app, 'Website-dev', { httpApi: devBackend.httpApi, env: { account: ACCOUNT_ID, region: REGION } });
 devWebsite.addDependency(devBackend);
 
 // The prod stacks that the GitHub action deploys to
-const prodBackend = new BackendStack(app, 'TinyMu-prod', { env: { account: ACCOUNT_ID, region: REGION } });
+const prodBackend = new BackendStack(app, 'Backend-prod', { env: { account: ACCOUNT_ID, region: REGION } });
 const prodWebsite = new WebsiteStack(app, 'Website-prod', { httpApi: prodBackend.httpApi, env: { account: ACCOUNT_ID, region: REGION } });
 prodWebsite.addDependency(prodBackend);

--- a/packages/infra/lib/backend-stack.ts
+++ b/packages/infra/lib/backend-stack.ts
@@ -85,7 +85,7 @@ export class BackendStack extends cdk.Stack {
         // I can't add the CloudFront distribution here since we need to create that after this,
         // so maybe we set these as headers in the Lambda instead and pass in the CloudFront
         // distribution URL to the Lambda as an environment variable
-        allowOrigins: ['https://tiny.mu', 'http://localhost', 'http://localhost:3000'],
+        allowOrigins: ['https://short.as', 'http://localhost', 'http://localhost:3000'],
       },
     });
 

--- a/packages/infra/lib/cloudfront-functions/html-redirect.js
+++ b/packages/infra/lib/cloudfront-functions/html-redirect.js
@@ -1,8 +1,8 @@
 /**
  * Redirects the following:
- * - https://tiny.mu/site -> https://tiny.mu/site/index.html
- * - https://tiny.mu/site/folder/ -> https://tiny.mu/site/folder/index.html
- * - https://tiny.mu/site/page -> https://tiny.mu/site/page.html
+ * - https://short.as/site -> https://short.as/site/index.html
+ * - https://short.as/site/folder/ -> https://short.as/site/folder/index.html
+ * - https://short.as/site/page -> https://short.as/site/page.html
  */
 async function handler(event) {
   const request = event.request;

--- a/packages/infra/lib/cloudfront-functions/root-redirect.js
+++ b/packages/infra/lib/cloudfront-functions/root-redirect.js
@@ -1,7 +1,7 @@
 /**
  * Redirects the following:
- * - https://tiny.mu/ -> https://tiny.mu/site/ so that CloudFront redirects to the S3 website
- * - https://tiny.mu/aaaaaaa/ -> https://tiny.mu/aaaaaaa so that CloudFront calls the `get-long-url` API correctly
+ * - https://short.as/ -> https://short.as/site/ so that CloudFront redirects to the S3 website
+ * - https://short.as/aaaaaaa/ -> https://short.as/aaaaaaa so that CloudFront calls the `get-long-url` API correctly
  */
 async function handler(event) {
   const request = event.request;

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -26,7 +26,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "KeyType": "HASH",
           },
         ],
-        "TableName": "TestTinyMuStack-CountBucketsTable",
+        "TableName": "TestBackendStack-CountBucketsTable",
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
@@ -54,7 +54,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             },
           },
         },
-        "FunctionName": "TestTinyMuStack-CreateShortUrlLambda",
+        "FunctionName": "TestBackendStack-CreateShortUrlLambda",
         "Handler": "index.createShortUrlHandler",
         "Role": {
           "Fn::GetAtt": [
@@ -156,7 +156,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             },
           },
         },
-        "FunctionName": "TestTinyMuStack-GetLongUrlLambda",
+        "FunctionName": "TestBackendStack-GetLongUrlLambda",
         "Handler": "index.getLongUrlHandler",
         "Role": {
           "Fn::GetAtt": [
@@ -238,12 +238,12 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "POST",
           ],
           "AllowOrigins": [
-            "https://tiny.mu",
+            "https://short.as",
             "http://localhost",
             "http://localhost:3000",
           ],
         },
-        "Name": "TestTinyMuStack-HttpAPI",
+        "Name": "TestBackendStack-HttpAPI",
         "ProtocolType": "HTTP",
       },
       "Type": "AWS::ApiGatewayV2::Api",
@@ -422,7 +422,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "KeyType": "HASH",
           },
         ],
-        "TableName": "TestTinyMuStack-UrlsTable",
+        "TableName": "TestBackendStack-UrlsTable",
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
@@ -845,7 +845,7 @@ exports[`Snapshot tests Website stack matches snapshot 1`] = `
                           [
                             "https://",
                             {
-                              "Fn::ImportValue": "TestTinyMuBackendStack:ExportsOutputRefHttpAPI8D545486FD78B06F",
+                              "Fn::ImportValue": "TestBackendStack:ExportsOutputRefHttpAPI8D545486FD78B06F",
                             },
                             ".execute-api.",
                             {
@@ -898,9 +898,9 @@ exports[`Snapshot tests Website stack matches snapshot 1`] = `
         "AutoPublish": true,
         "FunctionCode": "/**
  * Redirects the following:
- * - https://tiny.mu/site -> https://tiny.mu/site/index.html
- * - https://tiny.mu/site/folder/ -> https://tiny.mu/site/folder/index.html
- * - https://tiny.mu/site/page -> https://tiny.mu/site/page.html
+ * - https://short.as/site -> https://short.as/site/index.html
+ * - https://short.as/site/folder/ -> https://short.as/site/folder/index.html
+ * - https://short.as/site/page -> https://short.as/site/page.html
  */
 async function handler(event) {
   const request = event.request;
@@ -937,8 +937,8 @@ async function handler(event) {
         "AutoPublish": true,
         "FunctionCode": "/**
  * Redirects the following:
- * - https://tiny.mu/ -> https://tiny.mu/site/ so that CloudFront redirects to the S3 website
- * - https://tiny.mu/aaaaaaa/ -> https://tiny.mu/aaaaaaa so that CloudFront calls the \`get-long-url\` API correctly
+ * - https://short.as/ -> https://short.as/site/ so that CloudFront redirects to the S3 website
+ * - https://short.as/aaaaaaa/ -> https://short.as/aaaaaaa so that CloudFront calls the \`get-long-url\` API correctly
  */
 async function handler(event) {
   const request = event.request;

--- a/packages/infra/test/app.test.ts
+++ b/packages/infra/test/app.test.ts
@@ -21,7 +21,7 @@ describe('Snapshot tests', () => {
     const app = new cdk.App();
     
     /* When */
-    const stack = new BackendStack(app, 'TestTinyMuStack');
+    const stack = new BackendStack(app, 'TestBackendStack');
     const template = Template.fromStack(stack);
     
     /* Then */
@@ -33,7 +33,7 @@ describe('Snapshot tests', () => {
     const app = new cdk.App();
 
     /* When */
-    const backendStack = new BackendStack(app, 'TestTinyMuBackendStack');
+    const backendStack = new BackendStack(app, 'TestBackendStack');
     const websiteStack = new WebsiteStack(app, 'TestWebsiteStack', { httpApi: backendStack.httpApi });
     const template = Template.fromStack(websiteStack);
 

--- a/packages/site/src/app/page.tsx
+++ b/packages/site/src/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
               });
               const json = await data.json();
               console.log(json);
-            }}>Make it tiny</Button>
+            }}>Make it short as</Button>
 
             <Button onClick={async () => {
               // Had to add http://localhost:3000 to allowed origins in API Gateway


### PR DESCRIPTION
- Change all `tiny.mu` references to `short.as`
- Rename the backend stack from `TinyMu-*` to `Backend-*`, I will have to manually delete the old `TinyMu` stack once this CR is merged and the GitHub action deploys the new stack