### PR TITLE
Add `short.as` domain to prod stage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: youyo/aws-cdk-github-actions@v2
         with:
           cdk_subcommand: 'deploy'
-          cdk_stack: '@(Backend-prod|Website-prod)'
+          cdk_stack: '@(Domain-prod|Backend-prod|Website-prod)'
           cdk_args: '--require-approval never'
           working_dir: './packages/infra/'
           actions_comment: false

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -27,7 +27,7 @@ jobs:
         uses: youyo/aws-cdk-github-actions@v2
         with:
           cdk_subcommand: 'diff'
-          cdk_stack: '@(Backend-prod|Website-prod)'
+          cdk_stack: '@(Domain-prod|Backend-prod|Website-prod)'
           working_dir: './packages/infra/'
           actions_comment: false
         env:

--- a/packages/infra/bin/app.ts
+++ b/packages/infra/bin/app.ts
@@ -3,9 +3,11 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { BackendStack } from '../lib/backend-stack';
 import { WebsiteStack } from '../lib/website-stack';
+import { ProdDomainStack } from '../lib/prod-domain-stack';
 
 const ACCOUNT_ID = '381492110289';
 const REGION = 'eu-west-2';
+const US_EAST_1_REGION = 'us-east-1';
 
 const app = new cdk.App();
 
@@ -15,6 +17,15 @@ const devWebsite = new WebsiteStack(app, 'Website-dev', { httpApi: devBackend.ht
 devWebsite.addDependency(devBackend);
 
 // The prod stacks that the GitHub action deploys to
+const prodDomain = new ProdDomainStack(app, 'Domain-prod', { env: { account: ACCOUNT_ID, region: US_EAST_1_REGION }, crossRegionReferences: true });
 const prodBackend = new BackendStack(app, 'Backend-prod', { env: { account: ACCOUNT_ID, region: REGION } });
-const prodWebsite = new WebsiteStack(app, 'Website-prod', { httpApi: prodBackend.httpApi, env: { account: ACCOUNT_ID, region: REGION } });
+const prodWebsite = new WebsiteStack(app, 'Website-prod', {
+  isProd: true,
+  hostedZone: prodDomain.hostedZone,
+  certificate: prodDomain.certificate,
+  httpApi: prodBackend.httpApi,
+  env: { account: ACCOUNT_ID, region: REGION },
+  crossRegionReferences: true
+});
+prodWebsite.addDependency(prodDomain);
 prodWebsite.addDependency(prodBackend);

--- a/packages/infra/lib/prod-domain-stack.ts
+++ b/packages/infra/lib/prod-domain-stack.ts
@@ -1,0 +1,39 @@
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as cdk from 'aws-cdk-lib';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import { Construct } from 'constructs';
+
+interface ProdDomainStackProps extends cdk.StackProps {};
+
+/**
+ * This stack creates:
+ * - the Route53 HostedZone that will act as the DNS service for the short.as domain
+ * - the SSL/TLS certificate for the domain
+ * 
+ * This should only be deployed to prod, and should only be deployed to the `us-east-1` region
+ * since ACM certificates that are used with CloudFront must be in the `us-east-1` region.
+ * 
+ * Documentation about using Route53 as the DNS service for a domain:
+ * https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/migrate-dns-domain-inactive.html
+ * 
+ * Documentation about accessing an ACM certificate cross stack/region:
+ * https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager-readme.html#cross-region-certificates
+ */
+export class ProdDomainStack extends cdk.Stack {
+  public hostedZone: route53.HostedZone;
+
+  public certificate: acm.Certificate;
+
+  constructor(scope: Construct, id: string, props: ProdDomainStackProps) {
+    super(scope, id, props);
+
+    this.hostedZone = new route53.HostedZone(this, 'HostedZone', { zoneName: 'short.as' });
+
+    // TODO: set up redirects from www.short.as to short.as
+    this.certificate = new acm.Certificate(this, 'Certificate', {
+      domainName: 'short.as',
+      subjectAlternativeNames: ['www.short.as'],
+      validation: acm.CertificateValidation.fromDns(this.hostedZone)
+    });
+  }
+}


### PR DESCRIPTION
The prod website is now available at https://short.as

Followed various AWS resources:
- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/migrate-dns-domain-inactive.html
- https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager-readme.html#cross-region-certificates
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-cloudfront-distribution.html

Note that the name servers created by the `HostedZone` were then manually copy/pasted into the `short.as` domain management panel on the [nic.as](https://nic.as/) website.
