### PR TITLE
Remove unnecessary Link tags

### DIFF
--- a/packages/site/src/app/page.tsx
+++ b/packages/site/src/app/page.tsx
@@ -10,7 +10,6 @@ import { Separator } from "@/components/ui/separator";
 import { QRCodeDrawerDialog } from "@/components/qr-code";
 import { ArrowUpRight, ClipboardCopy, Minimize2, Repeat } from "lucide-react";
 import { SetStateAction, useState } from "react";
-import Link from "next/link";
 import { ShareMenu } from "@/components/share-menu";
 
 // Data fetching from the client in Next.js:
@@ -127,9 +126,9 @@ const HasShortenedCard = ({ longUrl, setLongUrl, shortUrlId, setShortUrlId, setI
             <Tooltip delayDuration={250}>
               <TooltipTrigger>
                 <Button variant="outline" size="icon" asChild>
-                  <Link href={shortUrl}>
+                  <a href={shortUrl}>
                     <ArrowUpRight className="h-4 w-4" />
-                  </Link>
+                  </a>
                 </Button>
               </TooltipTrigger>
               <TooltipContent>

--- a/packages/site/src/components/share-menu.tsx
+++ b/packages/site/src/components/share-menu.tsx
@@ -14,7 +14,6 @@ import {
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import Link from "next/link";
 import React from "react";
 
 const sharingTitle = "Check out my short.as link!";
@@ -53,36 +52,36 @@ export const ShareMenu = ({ shortUrl }: { shortUrl: string }) => {
         <DropdownMenuLabel>Share</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
-          <Link href={`https://www.facebook.com/sharer.php?u=${shortUrl}`}>
+          <a href={`https://www.facebook.com/sharer.php?u=${shortUrl}`}>
             <DropdownMenuItem>
               <SiFacebook className="mr-2 h-4 w-4" />
               <span>Facebook</span>
             </DropdownMenuItem>
-          </Link>
-          <Link href={`https://twitter.com/intent/tweet?url=${shortUrl}&text=${sharingTitle}&hashtags=short.as`}>
+          </a>
+          <a href={`https://twitter.com/intent/tweet?url=${shortUrl}&text=${sharingTitle}&hashtags=short.as`}>
             <DropdownMenuItem>
               <SiX className="mr-2 h-4 w-4" />
               <span>Twitter</span>
             </DropdownMenuItem>
-          </Link>
-          <Link href={`https://www.linkedin.com/sharing/share-offsite/?url=${shortUrl}`}>
+          </a>
+          <a href={`https://www.linkedin.com/sharing/share-offsite/?url=${shortUrl}`}>
             <DropdownMenuItem>
               <SiLinkedin className="mr-2 h-4 w-4" />
               <span>LinkedIn</span>
             </DropdownMenuItem>
-          </Link>
-          <Link href={`https://reddit.com/submit?url=${shortUrl}&title=${sharingTitle}`}>
+          </a>
+          <a href={`https://reddit.com/submit?url=${shortUrl}&title=${sharingTitle}`}>
             <DropdownMenuItem>
               <SiReddit className="mr-2 h-4 w-4" />
               <span>Reddit</span>
             </DropdownMenuItem>
-          </Link>
-          <Link href={`mailto:?subject=${sharingTitle}&body=${shortUrl}`}>
+          </a>
+          <a href={`mailto:?subject=${sharingTitle}&body=${shortUrl}`}>
             <DropdownMenuItem>
               <Mail className="mr-2 h-4 w-4" />
               <span>Email</span>
             </DropdownMenuItem>
-          </Link>
+          </a>
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -115,34 +114,34 @@ export const ShareMenu = ({ shortUrl }: { shortUrl: string }) => {
           </DrawerHeader>
           <div className="grid items-start gap-1">
             <Button asChild type="submit" variant="ghost" style={{ justifyContent: "flex-start" }}>
-              <Link href={`https://www.facebook.com/sharer.php?u=${shortUrl}`}>
+              <a href={`https://www.facebook.com/sharer.php?u=${shortUrl}`}>
                 <SiFacebook className="mr-2 h-4 w-4" />
                 <span>Facebook</span>
-              </Link>
+              </a>
             </Button>
             <Button asChild type="submit" variant="ghost" style={{ justifyContent: "flex-start" }}>
-              <Link href={`https://twitter.com/intent/tweet?url=${shortUrl}&text=${sharingTitle}&hashtags=short.as`}>
+              <a href={`https://twitter.com/intent/tweet?url=${shortUrl}&text=${sharingTitle}&hashtags=short.as`}>
                 <SiX className="mr-2 h-4 w-4" />
                 <span>Twitter</span>
-              </Link>
+              </a>
             </Button>
             <Button asChild type="submit" variant="ghost" style={{ justifyContent: "flex-start" }}>
-              <Link href={`https://www.linkedin.com/sharing/share-offsite/?url=${shortUrl}`}>
+              <a href={`https://www.linkedin.com/sharing/share-offsite/?url=${shortUrl}`}>
                 <SiLinkedin className="mr-2 h-4 w-4" />
                 <span>LinkedIn</span>
-              </Link>
+              </a>
             </Button>
             <Button asChild type="submit" variant="ghost" style={{ justifyContent: "flex-start" }}>
-              <Link href={`https://reddit.com/submit?url=${shortUrl}&title=${sharingTitle}`}>
+              <a href={`https://reddit.com/submit?url=${shortUrl}&title=${sharingTitle}`}>
                 <SiReddit className="mr-2 h-4 w-4" />
                 <span>Reddit</span>
-              </Link>
+              </a>
             </Button>
             <Button asChild type="submit" variant="ghost" style={{ justifyContent: "flex-start" }}>
-              <Link href={`mailto:?subject=${sharingTitle}&body=${shortUrl}`}>
+              <a href={`mailto:?subject=${sharingTitle}&body=${shortUrl}`}>
                 <Mail className="mr-2 h-4 w-4" />
                 <span>Email</span>
-              </Link>
+              </a>
             </Button>
           </div>
           <DrawerFooter className="pt-2" />

--- a/packages/site/src/components/site-header.tsx
+++ b/packages/site/src/components/site-header.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 import { Button } from "@/components/ui/button";
 import { MainNav } from "@/components/ui/main-nav";
 import { ModeToggle } from "@/components/ui/mode-toggle";
@@ -13,9 +11,9 @@ export function SiteHeader() {
         <div className="flex flex-1 items-center justify-end space-x-4">
           <nav className="flex items-center space-x-1">
             <Button variant="ghost" size="icon" asChild>
-              <Link href="https://github.com/ainsleyrutterford/short.as">
+              <a href="https://github.com/ainsleyrutterford/short.as">
                 <MarkGithubIcon className="h-[1.2rem] w-[1.2rem]" />
-              </Link>
+              </a>
             </Button>
             <ModeToggle />
           </nav>


### PR DESCRIPTION
The [NextJS `Link` component](https://nextjs.org/learn-pages-router/basics/navigate-between-pages/link-component) should only be used to navigate between pages in the application. This PR changes all instances that linked to external sites to use the `a` tag instead.

This should hopefully stop the fetching of files like `{shortUrlId}.txt?_rsc=acgkz`, though the `About` and `Create` pages still use the `Link` component so they will probably still have this fetching enabled.

I will look into either:

- making these `.txt` files accessible by the browser (NextJS is currently looking for them under `short.as/about.txt?_rsc=acgkz` instead of `short.as/site/about.txt?_rsc=acgkz`, or
- just changing these links to use the `a` tag as well.
