### PR TITLE
Use Arm64 instead of x64 for Lambdas

### DIFF
--- a/packages/infra/lib/backend-stack.ts
+++ b/packages/infra/lib/backend-stack.ts
@@ -6,6 +6,7 @@ import { Construct } from "constructs";
 import { LlrtFunction } from "cdk-lambda-llrt";
 import { PolicyStatement, Effect } from "aws-cdk-lib/aws-iam";
 import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import { Architecture } from "aws-cdk-lib/aws-lambda";
 
 export class BackendStack extends cdk.Stack {
   public httpApi: apigateway.HttpApi;
@@ -35,6 +36,7 @@ export class BackendStack extends cdk.Stack {
       // This filepath is relative to the root of the infra package I believe
       entry: "../lambda/src/index.ts",
       handler: "createShortUrlHandler",
+      architecture: Architecture.ARM_64,
       functionName: this.createResourceName("CreateShortUrlLambda"),
       environment: {
         COUNT_BUCKETS_TABLE_NAME: countBucketsTable.tableName,
@@ -46,6 +48,7 @@ export class BackendStack extends cdk.Stack {
       // This filepath is relative to the root of the infra package I believe
       entry: "../lambda/src/index.ts",
       handler: "getLongUrlHandler",
+      architecture: Architecture.ARM_64,
       functionName: this.createResourceName("GetLongUrlLambda"),
       environment: {
         URLS_TABLE_NAME: urlsTable.tableName,

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -37,6 +37,9 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
         "CreateShortUrlLambdaServiceRole009F038F",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -142,6 +145,9 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
         "GetLongUrlLambdaServiceRole025A1693",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",


### PR DESCRIPTION
According to [Lambda Perf](https://maxday.github.io/lambda-perf/), Arm64 is slightly faster than x86 for LLRT. The `LlrtFunction` CDK construct we are using allows you to select the architecture by [providing an `architecture` prop](https://github.com/tmokmss/cdk-lambda-llrt/blob/b9e41f7ff667a0622e627c7568205f53aa7ec547/src/llrt-function.ts#L19).