### PR TITLE
Various frontend fixes

### DIFF
--- a/packages/infra/lib/cloudfront-functions/root-redirect.js
+++ b/packages/infra/lib/cloudfront-functions/root-redirect.js
@@ -1,14 +1,13 @@
 /**
  * Redirects the following:
- * - https://short.as/ -> https://short.as/create/ so that CloudFront redirects to the S3 website
+ * - https://short.as/ -> https://short.as/create so that CloudFront redirects to the S3 website
  * - https://short.as/aaaaaaa/ -> https://short.as/aaaaaaa so that CloudFront calls the `get-long-url` API correctly
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function handler(event) {
   const request = event.request;
   const host = request.headers.host.value;
-  // TODO: remove the trailing slash?
-  const newUrl = `https://${host}/create/`;
+  const newUrl = `https://${host}/create`;
 
   if (request.uri === "/") {
     return {

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -1120,15 +1120,14 @@ async function handler(event) {
         "AutoPublish": true,
         "FunctionCode": "/**
  * Redirects the following:
- * - https://short.as/ -> https://short.as/create/ so that CloudFront redirects to the S3 website
+ * - https://short.as/ -> https://short.as/create so that CloudFront redirects to the S3 website
  * - https://short.as/aaaaaaa/ -> https://short.as/aaaaaaa so that CloudFront calls the \`get-long-url\` API correctly
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function handler(event) {
   const request = event.request;
   const host = request.headers.host.value;
-  // TODO: remove the trailing slash?
-  const newUrl = \`https://\${host}/create/\`;
+  const newUrl = \`https://\${host}/create\`;
 
   if (request.uri === "/") {
     return {

--- a/packages/site/src/app/about/page.tsx
+++ b/packages/site/src/app/about/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 export default function About() {
   return <h1>This is an about page!</h1>;
 }

--- a/packages/site/src/app/layout.tsx
+++ b/packages/site/src/app/layout.tsx
@@ -35,7 +35,6 @@ export default function RootLayout({
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <TooltipProvider>
-            {/* TODO: the about page has a messed up color scheme now (always seems to be dark) */}
             <SiteHeader />
             <IdsProvider>
               <div className="max-w-screen-md mx-auto px-4 pt-10 sm:pt-16">{children}</div>

--- a/packages/site/src/app/not-found.tsx
+++ b/packages/site/src/app/not-found.tsx
@@ -1,0 +1,11 @@
+import { Separator } from "@/components/ui/separator";
+
+export default function NotFound() {
+  return (
+    <div className="flex h-10 items-center justify-center space-x-4 mt-20">
+      <p className="text-2xl font-semibold">404</p>
+      <Separator orientation="vertical" />
+      <div>This page could not be found</div>
+    </div>
+  );
+}

--- a/packages/site/src/app/u/page.tsx
+++ b/packages/site/src/app/u/page.tsx
@@ -15,6 +15,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useTheme } from "next-themes";
+import { toast } from "sonner";
 
 const TextGradient = ({ text }: { text: string }) => {
   const { resolvedTheme } = useTheme();
@@ -93,12 +94,16 @@ const ShortUrlDetailsContents = () => {
                   className="w-full"
                   onClick={async () => {
                     navigator.clipboard.writeText(shortUrl);
+                    toast("Copied to clipboard!", {
+                      description: shortUrl,
+                      duration: 3000,
+                    });
                   }}
                 >
                   <ClipboardCopy className="mr-2 h-4 w-4" />
                   Copy short URL
                 </Button>
-                <Link href="/">
+                <Link href="/" prefetch={false}>
                   <Button className="w-full" variant="secondary">
                     <Repeat className="mr-2 h-4 w-4" />
                     Shorten another

--- a/packages/site/src/components/ui/main-nav.tsx
+++ b/packages/site/src/components/ui/main-nav.tsx
@@ -1,6 +1,22 @@
+"use client";
+
 import Link from "next/link"
 
 import { cn } from "@/lib/utils"
+import { usePathname } from "next/navigation"
+
+const NavItem = ({ href, text, prefetch }: { href: string; text: string; prefetch?: boolean }) => {
+  const location = usePathname();
+  return (
+    <Link
+      href={href}
+      prefetch={prefetch}
+      className={`${location !== href ? "text-muted-foreground" : ""} text-sm font-medium transition-colors hover:text-primary`}
+    >
+      {text}
+    </Link>
+  );
+};
 
 export function MainNav({
   className,
@@ -11,19 +27,10 @@ export function MainNav({
       className={cn("flex items-center space-x-4 lg:space-x-6", className)}
       {...props}
     >
-      <Link
-        href="/"
-        // TODO: highlight the link if it is for the page we are currently on, use the location hook to check or something
-        className="text-sm font-medium transition-colors hover:text-primary"
-      >
-        Create
-      </Link>
-      <Link
-        href="/about"
-        className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
-      >
-        About
-      </Link>
+      {/* We had to disable prefetching because the file created by NextJS would be reachable under
+      `./${basePath}/index.txt` but the prefetching was trying to fetch `./create.txt` instead */}
+      <NavItem href="/" text="Create" prefetch={false} />
+      <NavItem href="/about" text="About" />
     </nav>
   )
 }


### PR DESCRIPTION
- Updates the redirect CloudFront Function so that it redirects to `/create` instead of `/create/`
- Adds a 404 not found page so that the 404 page is now styled and uses light or dark mode rather than always being dark mode
- Adds a sonner (toast) when a URL is copied to the clipboard
- Disables prefetching for the home page links since NextJS was generating the wrong `.txt` file (see the comments I added in the code for more info)
- Updates the nav bar so that the colour of the links now reflects which page the user is on