### PR TITLE
Add loading spinner and prevent overflow on URL details page

### DIFF
--- a/packages/site/src/app/page.tsx
+++ b/packages/site/src/app/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Minimize2 } from "lucide-react";
+import { Loader2, Minimize2 } from "lucide-react";
 import { useState } from "react";
 import { getValidUrl } from "@/lib/url";
 import { useRouter } from "next/navigation";
@@ -21,6 +21,7 @@ const ToShortenCard = () => {
 
   const [urlToShorten, setUrlToShorten] = useState("");
   const [isValidUrl, setIsValidUrl] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   return (
     <Card>
@@ -36,6 +37,7 @@ const ToShortenCard = () => {
 
           try {
             setLongUrl(validatedUrl);
+            setLoading(true);
 
             const data = await window.fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/create-short-url`, {
               method: "POST",
@@ -45,6 +47,7 @@ const ToShortenCard = () => {
 
             const json = await data.json();
             setShortUrlId(json.shortUrlId);
+            setLoading(false);
 
             router.push(`/u?i=${json.shortUrlId}`);
           } catch (error) {
@@ -95,7 +98,7 @@ const ToShortenCard = () => {
         </CardContent>
         <CardFooter>
           <Button type="submit" className="w-full">
-            <Minimize2 className="mr-2 h-4 w-4" />
+            {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Minimize2 className="mr-2 h-4 w-4" />}
             Make it short as
           </Button>
         </CardFooter>

--- a/packages/site/src/components/qr-code.tsx
+++ b/packages/site/src/components/qr-code.tsx
@@ -22,6 +22,7 @@ import {
 import { Download, QrCode } from "lucide-react";
 import ReactQRCode from "react-qr-code";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useTheme } from "next-themes";
 
 const QR_CODE_ID = "QRCode";
 const FILENAME = "Short.as QRCode";
@@ -39,11 +40,13 @@ const downloadAsPng = () => {
   const ctx = canvas.getContext("2d");
   const image = new Image();
 
+  const resolution = 1024;
+
   image.onload = () => {
-    canvas.width = image.width;
-    canvas.height = image.height;
+    canvas.width = resolution;
+    canvas.height = resolution;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    ctx!.drawImage(image, 0, 0);
+    ctx!.drawImage(image, 0, 0, canvas.width, canvas.height);
     const pngFile = canvas.toDataURL("image/png");
     const link = document.createElement("a");
     link.download = `${FILENAME}.png`;
@@ -69,26 +72,30 @@ const downloadAsSvg = () => {
   link.click();
 };
 
-const StyledQRCode = ({ shortUrl }: QRCodeProps) => (
-  <div
-    style={{
-      height: "128px",
-      width: "128px",
-      marginLeft: "auto",
-      marginRight: "auto",
-      marginTop: "20px",
-      marginBottom: "20px",
-    }}
-  >
-    <ReactQRCode
-      fgColor="hsl(var(--foreground))"
-      bgColor="hsl(var(--background))"
-      id={QR_CODE_ID}
-      style={{ height: "auto", maxWidth: "100%", width: "100%" }}
-      value={shortUrl}
-    />
-  </div>
-);
+const StyledQRCode = ({ shortUrl }: QRCodeProps) => {
+  const { resolvedTheme } = useTheme();
+
+  return (
+    <div
+      style={{
+        height: "128px",
+        width: "128px",
+        marginLeft: "auto",
+        marginRight: "auto",
+        marginTop: "20px",
+        marginBottom: "20px",
+      }}
+    >
+      <ReactQRCode
+        fgColor={resolvedTheme === "light" ? "#000000" : "#FFFFFF"}
+        bgColor="rgba(0, 0, 0, 0)"
+        id={QR_CODE_ID}
+        style={{ height: "auto", maxWidth: "100%", width: "100%" }}
+        value={shortUrl}
+      />
+    </div>
+  );
+};
 
 export const QRCodeDrawerDialog = ({ shortUrl }: QRCodeProps) => {
   const [open, setOpen] = React.useState(false);

--- a/packages/site/src/components/ui/input.tsx
+++ b/packages/site/src/components/ui/input.tsx
@@ -34,10 +34,10 @@ Input.displayName = "Input"
  * just gone with a `<div>` instead.
  */
 const ReadOnlyInput = ({ text, fadeIn }: { text: string; fadeIn?: boolean }) =>
-  <div className="flex items-center h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50">
-    {text && <div className={fadeIn ? "animate-fade-in-zoom" : ""}>
+  <div className="flex overflow-hidden items-center h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50">
+    {text && <p className={`whitespace-nowrap ${fadeIn ? "animate-fade-in" : ""}`}>
       {text}
-    </div>}
+    </p>}
   </div>;
 
 export { Input, ReadOnlyInput }

--- a/packages/site/tailwind.config.ts
+++ b/packages/site/tailwind.config.ts
@@ -70,16 +70,16 @@ const config = {
         gradient: {
           to: { "background-position": "200% center" },
         },
-        "fade-in-zoom": {
-          "0%": { opacity: "0", transform: "scale(0.97)" },
-          "100%": { opacity: "1", transform: "scale(1)" },
+        "fade-in": {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
         },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         gradient: "gradient 6.5s linear infinite",
-        "fade-in-zoom": "fade-in-zoom 0.3s ease-in-out",
+        "fade-in": "fade-in 0.3s ease-in-out",
       },
     },
   },


### PR DESCRIPTION
- Added a loading spinner for the "Make it short as" button
- The resolution for PNG QR codes is now 1024x1024 instead of 256x256
- Fixed the colours of the downloaded PNG and SVG QR codes, they were always black for both foreground and background (I think this was because I was referencing CSS variables instead of specifying the colours)
- Fixed overflowing when the URL was too long on the URL details page