### PR TITLE
Implement Lambda warming for CreateShortUrl and GetLongUrl

### DIFF
--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -143,6 +143,55 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CreateShortUrlLambdaWarmingRuleAllowEventRuleTestBackendStackCreateShortUrlLambdaCA169B5AABC6240B": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "CreateShortUrlLambda0AED869B",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "CreateShortUrlLambdaWarmingRuleB803B886",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "CreateShortUrlLambdaWarmingRuleB803B886": {
+      "Properties": {
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "Warming rule for ",
+              {
+                "Ref": "CreateShortUrlLambda0AED869B",
+              },
+            ],
+          ],
+        },
+        "ScheduleExpression": "rate(5 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "CreateShortUrlLambda0AED869B",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": "{"warming":true}",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "GetLongUrlDetailsLambda3B6B278A": {
       "DependsOn": [
         "GetLongUrlDetailsLambdaServiceRoleDefaultPolicyE8B99266",
@@ -334,6 +383,55 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "GetLongUrlLambdaWarmingRule8130972C": {
+      "Properties": {
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "Warming rule for ",
+              {
+                "Ref": "GetLongUrlLambdaC5112ECB",
+              },
+            ],
+          ],
+        },
+        "ScheduleExpression": "rate(5 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "GetLongUrlLambdaC5112ECB",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": "{"warming":true}",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "GetLongUrlLambdaWarmingRuleAllowEventRuleTestBackendStackGetLongUrlLambdaCE717209AFA84177": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "GetLongUrlLambdaC5112ECB",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "GetLongUrlLambdaWarmingRule8130972C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "HttpAPI8D545486": {
       "Properties": {

--- a/packages/lambda/src/handlers/get-long-url.ts
+++ b/packages/lambda/src/handlers/get-long-url.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEventV2, APIGatewayProxyHandlerV2, APIGatewayProxyStructuredResultV2 } from "aws-lambda";
 // Make sure to import commands from lib-dynamodb instead of client-dynamodb
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
-import { getStringEnvironmentVariable, response } from "../utils";
+import { getStringEnvironmentVariable, response, warmingWrapper } from "../utils";
 import { dynamoClient } from "../clients/dynamo";
 
 interface PathParameters {
@@ -53,10 +53,10 @@ export const getLongUrlDetailsHandler: APIGatewayProxyHandlerV2 = async (event, 
     : maybeLongUrl;
 };
 
-export const getLongUrlHandler: APIGatewayProxyHandlerV2 = async (event, _context) => {
+export const getLongUrlHandler: APIGatewayProxyHandlerV2 = warmingWrapper(async (event, _context) => {
   console.log(event);
   const maybeLongUrl = await getLongUrl(event);
   return typeof maybeLongUrl === "string"
     ? response({ statusCode: 302, headers: { Location: maybeLongUrl } })
     : maybeLongUrl;
-};
+});


### PR DESCRIPTION
For now, I'm just enabling this for the `CreateShortUrl` and `GetLongUrl` handlers to see how well it works. I'm doing it once every 5 mins as suggested [here](https://www.jeremydaly.com/15-key-takeaways-from-the-serverless-talk-at-aws-startup-day/).

In a follow up PR, I'll write a CDK construct to clean up our Lambdas like [this](https://github.com/ainsleyrutterford/short.as/commit/71f31d2ae3cfe51aa1fbe6702a01a773766c5cd5).