### PR TITLE
Update root-redirect CloudFront function to redirect non short URL ID requests to S3

### DIFF
--- a/packages/infra/lib/cloudfront-functions/root-redirect.js
+++ b/packages/infra/lib/cloudfront-functions/root-redirect.js
@@ -2,23 +2,38 @@
  * Redirects the following:
  * - https://short.as/ -> https://short.as/create so that CloudFront redirects to the S3 website
  * - https://short.as/aaaaaaa/ -> https://short.as/aaaaaaa so that CloudFront calls the `get-long-url` API correctly
+ * - https://short.as/some-value -> https://short.as/create/some-value (if some-value is not of length 7 or contains
+ * something other than lower and uppercase letters) so that CloudFront redirects to the S3 website
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function handler(event) {
   const request = event.request;
   const host = request.headers.host.value;
-  // TODO: when we update the CloudFront distribution so that S3 is the default,
-  // TODO: this can be changed to just /create
-  const newUrl = `https://${host}/create/shorten`;
+  const websitePrefix = "create";
 
   if (request.uri === "/") {
     return {
       statusCode: 302,
       statusDescription: "Found",
-      headers: { location: { value: newUrl } },
+      // TODO: when we update the CloudFront distribution so that S3 is the default,
+      // TODO: this can be changed to just /shorten
+      headers: { location: { value: `https://${host}/${websitePrefix}/shorten` } },
     };
-  } else if (request.uri.endsWith("/")) {
+  }
+
+  if (request.uri.endsWith("/")) {
     request.uri = request.uri.slice(0, -1);
+  }
+
+  // Short URL IDs are of length 7 and contain only lower and uppercase letters,
+  // so we redirect any differently shaped URIs to the S3 website. Note that the
+  // redirect URI starts with a "/" so we expect that before the 7 characters.
+  if (!/^\/[A-Za-z]{7}$/.test(request.uri)) {
+    return {
+      statusCode: 302,
+      statusDescription: "Found",
+      headers: { location: { value: `https://${host}/${websitePrefix}${request.uri}` } },
+    };
   }
 
   return request;

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -1524,23 +1524,38 @@ async function handler(event) {
  * Redirects the following:
  * - https://short.as/ -> https://short.as/create so that CloudFront redirects to the S3 website
  * - https://short.as/aaaaaaa/ -> https://short.as/aaaaaaa so that CloudFront calls the \`get-long-url\` API correctly
+ * - https://short.as/some-value -> https://short.as/create/some-value (if some-value is not of length 7 or contains
+ * something other than lower and uppercase letters) so that CloudFront redirects to the S3 website
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function handler(event) {
   const request = event.request;
   const host = request.headers.host.value;
-  // TODO: when we update the CloudFront distribution so that S3 is the default,
-  // TODO: this can be changed to just /create
-  const newUrl = \`https://\${host}/create/shorten\`;
+  const websitePrefix = "create";
 
   if (request.uri === "/") {
     return {
       statusCode: 302,
       statusDescription: "Found",
-      headers: { location: { value: newUrl } },
+      // TODO: when we update the CloudFront distribution so that S3 is the default,
+      // TODO: this can be changed to just /shorten
+      headers: { location: { value: \`https://\${host}/\${websitePrefix}/shorten\` } },
     };
-  } else if (request.uri.endsWith("/")) {
+  }
+
+  if (request.uri.endsWith("/")) {
     request.uri = request.uri.slice(0, -1);
+  }
+
+  // Short URL IDs are of length 7 and contain only lower and uppercase letters,
+  // so we redirect any differently shaped URIs to the S3 website. Note that the
+  // redirect URI starts with a "/" so we expect that before the 7 characters.
+  if (!/^\\/[A-Za-z]{7}$/.test(request.uri)) {
+    return {
+      statusCode: 302,
+      statusDescription: "Found",
+      headers: { location: { value: \`https://\${host}/\${websitePrefix}\${request.uri}\` } },
+    };
   }
 
   return request;


### PR DESCRIPTION
At the moment, the crawling that reaches our site results in quite a few `get-long-url` Lambda calls per day (~150) because the requests aren't to `short.as/create/...` they are to `short.as/...` (e.g. `short.as/robots.txt`) which is set to route to the `get-long-url` API Gateway path which is served by a Lambda.

With this change we only route to `get-long-url` if the request is of length 7 and contains only lower and uppercase letters (since this is the shape of our short URL IDs), everything else is redirected to `short.as/create/...` to be served by S3 instead. Tested this on https://dev.short.as and it works as expected.