### PR TITLE
Sheet styling improvements

### DIFF
--- a/packages/site/src/app/shorten/page.tsx
+++ b/packages/site/src/app/shorten/page.tsx
@@ -98,7 +98,6 @@ const ShortenPage = () => {
 
                 const json = await data.json();
                 setShortUrlId(json.shortUrlId);
-                setLoading(false);
 
                 router.push(`/u?i=${json.shortUrlId}`);
               } catch (error) {

--- a/packages/site/src/components/ui/sheet.tsx
+++ b/packages/site/src/components/ui/sheet.tsx
@@ -30,7 +30,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {
@@ -63,7 +63,7 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring/40 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <Cross2Icon className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>


### PR DESCRIPTION
- The loading state now stays enabled for the shorten URL button until the new page is loaded. Before this change the loading state would disable for a split second (or longer on bad connections) before the "shortened URL page" had loaded which looked funny.
- Decreased the transition time for opening the sheet on the markdown pages.
- Made the close button on the sheet less significant.