### PR TITLE
Add prod GitHub OAuth and update dev to use OAuth app instead of GitHub app

### DIFF
--- a/packages/lambda/src/oauth/login/github.ts
+++ b/packages/lambda/src/oauth/login/github.ts
@@ -1,8 +1,10 @@
+import { URLSearchParams } from "url";
 import { OAuthProvider } from "@short-as/types";
 
 import { fetchOAuthClientInformation } from "../utils";
 import { UserDdbInput } from "../types";
 import { OAuthLoginHandler } from "./login-handler";
+import { siteUrl } from "../../utils";
 
 interface GitHubOAuthResponse {
   access_token: string;
@@ -30,6 +32,7 @@ interface GitHubUser {
 }
 
 export class GitHubLoginHandler extends OAuthLoginHandler {
+  /** https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github */
   async fetchGitHubOAuthTokens(code: string): Promise<GitHubOAuthResponse> {
     const baseUrl = "https://github.com/login/oauth/access_token";
 
@@ -39,9 +42,10 @@ export class GitHubLoginHandler extends OAuthLoginHandler {
       code,
       client_id,
       client_secret,
+      redirect_uri: `${siteUrl}/api/oauth/github`,
     });
 
-    // https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#generating-a-user-access-token-when-a-user-installs-your-app
+    // https://github.com/orgs/community/discussions/150317?utm_source=chatgpt.com#discussioncomment-12009551
     const response = await fetch(baseUrl, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/packages/site/.env.dev
+++ b/packages/site/.env.dev
@@ -8,7 +8,9 @@ NEXT_PUBLIC_API_BASE_URL=https://dev.short.as/api
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=546157419504-bvapjctss93mfoum3d0l1j0hfbj451bs.apps.googleusercontent.com
 NEXT_PUBLIC_GOOGLE_OAUTH_REDIRECT_URL=https://dev.short.as/api/oauth/google
 
-NEXT_PUBLIC_GITHUB_CLIENT_ID=Iv23li99WGd8JJdmit89
+# https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+NEXT_PUBLIC_GITHUB_CLIENT_ID=Ov23ctdFq79lpppbt1is
+NEXT_PUBLIC_GITHUB_OAUTH_REDIRECT_URL=https://dev.short.as/api/oauth/github
 
 NEXT_PUBLIC_FACEBOOK_CLIENT_ID=574636505162538
 NEXT_PUBLIC_FACEBOOK_OAUTH_REDIRECT_URL=https://dev.short.as/api/oauth/facebook

--- a/packages/site/.env.prod
+++ b/packages/site/.env.prod
@@ -3,3 +3,14 @@
 NEXT_PUBLIC_STAGE=prod
 
 NEXT_PUBLIC_API_BASE_URL=https://short.as/api
+
+# https://developers.google.com/identity/protocols/oauth2
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=TODO
+NEXT_PUBLIC_GOOGLE_OAUTH_REDIRECT_URL=TODO
+
+# https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+NEXT_PUBLIC_GITHUB_CLIENT_ID=Ov23liHlnmCZ7hhftOTE
+NEXT_PUBLIC_GITHUB_OAUTH_REDIRECT_URL=https://short.as/api/oauth/github
+
+NEXT_PUBLIC_FACEBOOK_CLIENT_ID=TODO
+NEXT_PUBLIC_FACEBOOK_OAUTH_REDIRECT_URL=TODO

--- a/packages/site/src/app/login/page.tsx
+++ b/packages/site/src/app/login/page.tsx
@@ -8,10 +8,10 @@ import { GoogleLogo } from "@/assets/google";
 import { PageContainer } from "@/components/page-container";
 import { useRouter } from "next/navigation";
 
+/** https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient */
 const createGoogleOAuthUrl = () => {
   const baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
 
-  // https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient
   const queryStrings = new URLSearchParams({
     redirect_uri: process.env.NEXT_PUBLIC_GOOGLE_OAUTH_REDIRECT_URL ?? "",
     client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? "",
@@ -25,10 +25,14 @@ const createGoogleOAuthUrl = () => {
   return `${baseUrl}?${queryStrings.toString()}`;
 };
 
+/** https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity */
 const createGitHubOAuthUrl = () => {
   const baseUrl = "https://github.com/login/oauth/authorize";
 
-  const queryStrings = new URLSearchParams({ client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? "" });
+  const queryStrings = new URLSearchParams({
+    client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? "",
+    redirect_uri: process.env.NEXT_PUBLIC_GITHUB_OAUTH_REDIRECT_URL ?? "",
+  });
 
   return `${baseUrl}?${queryStrings.toString()}`;
 };


### PR DESCRIPTION
- Updated the client ID of dev to point to a new OAuth app instead of a GitHub app. Also updated the corresponding ID and secret in SSM Parameter store.
- Added a new client ID for prod (also added in SSM Parameter store).
- Added the `redirect_uri` in both steps as it's suggested by the GitHub docs.