### PR TITLE
Fix OAuth on Prod

### DIFF
--- a/packages/infra/bin/app.ts
+++ b/packages/infra/bin/app.ts
@@ -31,7 +31,10 @@ devWebsite.addDependency(devAndProdDomain);
 devWebsite.addDependency(devBackend);
 
 // The prod stacks that the GitHub action deploys
-const prodBackend = new BackendStack(app, "Backend-prod", { env: { account: ACCOUNT_ID, region: REGION } });
+const prodBackend = new BackendStack(app, "Backend-prod", {
+  env: { account: ACCOUNT_ID, region: REGION },
+  isProd: true,
+});
 const prodWebsite = new WebsiteStack(app, "Website-prod", {
   isProd: true,
   hostedZone: devAndProdDomain.hostedZone,

--- a/packages/lambda/src/oauth/login/facebook.ts
+++ b/packages/lambda/src/oauth/login/facebook.ts
@@ -20,12 +20,14 @@ interface FacebookUser {
 }
 
 export class FacebookLoginHandler extends OAuthLoginHandler {
+  oAuthProvider = OAuthProvider.Facebook;
+
   facebookOAuthBaseUrl = "https://graph.facebook.com/v21.0";
 
   async fetchFacebookOAuthTokens(code: string): Promise<FacebookOAuthResponse> {
     const baseUrl = `${this.facebookOAuthBaseUrl}/oauth/access_token`;
 
-    const { client_id, client_secret } = await fetchOAuthClientInformation(OAuthProvider.Facebook);
+    const { client_id, client_secret } = await fetchOAuthClientInformation(this.oAuthProvider);
 
     const queryStrings = new URLSearchParams({
       code,
@@ -66,8 +68,8 @@ export class FacebookLoginHandler extends OAuthLoginHandler {
     const facebookUser = await this.fetchFacebookUser(access_token);
 
     return {
-      id: `${OAuthProvider.Facebook}-${facebookUser.id}`,
-      oAuthProvider: OAuthProvider.Facebook,
+      id: `${this.oAuthProvider}-${facebookUser.id}`,
+      oAuthProvider: this.oAuthProvider,
       email: facebookUser.email,
       name: facebookUser.name,
       profilePictureUrl: facebookUser.picture,

--- a/packages/lambda/src/oauth/login/github.ts
+++ b/packages/lambda/src/oauth/login/github.ts
@@ -32,11 +32,13 @@ interface GitHubUser {
 }
 
 export class GitHubLoginHandler extends OAuthLoginHandler {
+  oAuthProvider = OAuthProvider.GitHub;
+
   /** https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github */
   async fetchGitHubOAuthTokens(code: string): Promise<GitHubOAuthResponse> {
     const baseUrl = "https://github.com/login/oauth/access_token";
 
-    const { client_id, client_secret } = await fetchOAuthClientInformation(OAuthProvider.GitHub);
+    const { client_id, client_secret } = await fetchOAuthClientInformation(this.oAuthProvider);
 
     const params = new URLSearchParams({
       code,
@@ -81,8 +83,8 @@ export class GitHubLoginHandler extends OAuthLoginHandler {
     const githubUser = await this.fetchGitHubUserData(access_token);
 
     return {
-      id: `${OAuthProvider.GitHub}-${githubUser.id}`,
-      oAuthProvider: OAuthProvider.GitHub,
+      id: `${this.oAuthProvider}-${githubUser.id}`,
+      oAuthProvider: this.oAuthProvider,
       email: githubUser.email,
       name: githubUser.name,
       profilePictureUrl: githubUser.avatar_url,

--- a/packages/lambda/src/oauth/login/google.ts
+++ b/packages/lambda/src/oauth/login/google.ts
@@ -33,10 +33,12 @@ interface GoogleUser {
 }
 
 export class GoogleLoginHandler extends OAuthLoginHandler {
+  oAuthProvider = OAuthProvider.Google;
+
   async fetchGoogleOAuthTokens(code: string): Promise<GoogleOAuthResponse> {
     const baseUrl = "https://oauth2.googleapis.com/token";
 
-    const { client_id, client_secret } = await fetchOAuthClientInformation(OAuthProvider.Google);
+    const { client_id, client_secret } = await fetchOAuthClientInformation(this.oAuthProvider);
 
     const queryStrings = new URLSearchParams({
       code,
@@ -60,8 +62,8 @@ export class GoogleLoginHandler extends OAuthLoginHandler {
 
     return {
       // We can't just use the sub as it isn't guaranteed to be unique for other providers too
-      id: `${OAuthProvider.Google}-${googleUser.sub}`,
-      oAuthProvider: OAuthProvider.Google,
+      id: `${this.oAuthProvider}-${googleUser.sub}`,
+      oAuthProvider: this.oAuthProvider,
       email: googleUser.email,
       name: googleUser.name,
       profilePictureUrl: googleUser.picture,

--- a/packages/lambda/src/oauth/login/login-handler.ts
+++ b/packages/lambda/src/oauth/login/login-handler.ts
@@ -8,7 +8,7 @@ import { UserDdbInput } from "../types";
 import { createLoggedInCookies, TESTING_LOCALHOST } from "../cookies";
 
 export abstract class OAuthLoginHandler {
-  private oAuthProvider: OAuthProvider | undefined;
+  protected oAuthProvider: OAuthProvider | undefined;
 
   private loggedInRedirectUrl = `${
     TESTING_LOCALHOST


### PR DESCRIPTION
Since we had not set `isProd` to true on the prod backend stack, the `IS_PROD` environment variable on the Lambda was false so it was using the dev SSM Parameters for the OAuth credentials rather than the prod ones.