### PR TITLE
Remove incorrect GSI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,11 @@
     "Ainsley",
     "KJUR",
     "Rutterford"
-  ]
+  ],
+  "github.copilot.enable": {
+    "*": false,
+    "plaintext": false,
+    "markdown": false,
+    "scminput": false
+  }
 }

--- a/packages/infra/lib/backend-stack.ts
+++ b/packages/infra/lib/backend-stack.ts
@@ -38,13 +38,13 @@ export class BackendStack extends cdk.Stack {
       tableName: this.createResourceName("UrlsTable"),
     });
 
-    const urlsTableUserIdGsi = "user-id-gsi";
+    // const urlsTableOwningUserIdGsi = "GSI-owningUserId-createdTimestamp";
 
-    urlsTable.addGlobalSecondaryIndex({
-      indexName: urlsTableUserIdGsi,
-      partitionKey: { name: "owningUserId", type: dynamodb.AttributeType.STRING },
-      sortKey: { name: "createdAt", type: dynamodb.AttributeType.STRING },
-    });
+    // urlsTable.addGlobalSecondaryIndex({
+    //   indexName: urlsTableOwningUserIdGsi,
+    //   partitionKey: { name: "owningUserId", type: dynamodb.AttributeType.STRING },
+    //   sortKey: { name: "createdTimestamp", type: dynamodb.AttributeType.STRING },
+    // });
 
     const usersTable = new dynamodb.Table(this, "UsersTable", {
       partitionKey: {
@@ -162,7 +162,7 @@ export class BackendStack extends cdk.Stack {
         environment: {
           URLS_TABLE_NAME: urlsTable.tableName,
           COUNT_BUCKETS_TABLE_NAME: countBucketsTable.tableName,
-          USER_ID_GSI_NAME: urlsTableUserIdGsi,
+          // USER_ID_GSI_NAME: urlsTableOwningUserIdGsi,
           USERS_TABLE_NAME: usersTable.tableName,
         },
       },
@@ -171,10 +171,10 @@ export class BackendStack extends cdk.Stack {
       warming: true,
       policyStatements: [
         new PolicyStatement({ actions: ["dynamodb:GetItem"], resources: [usersTable.tableArn] }),
-        new PolicyStatement({
-          actions: ["dynamodb:Query"],
-          resources: [`${urlsTable.tableArn}/index/${urlsTableUserIdGsi}`],
-        }),
+        // new PolicyStatement({
+        //   actions: ["dynamodb:Query"],
+        //   resources: [`${urlsTable.tableArn}/index/${urlsTableOwningUserIdGsi}`],
+        // }),
         new PolicyStatement({
           actions: ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:ConditionCheckItem"],
           resources: [countBucketsTable.tableArn, urlsTable.tableArn, usersTable.tableArn],

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -1047,34 +1047,8 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "AttributeName": "shortUrlId",
             "AttributeType": "S",
           },
-          {
-            "AttributeName": "owningUserId",
-            "AttributeType": "S",
-          },
-          {
-            "AttributeName": "createdAt",
-            "AttributeType": "S",
-          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
-        "GlobalSecondaryIndexes": [
-          {
-            "IndexName": "user-id-gsi",
-            "KeySchema": [
-              {
-                "AttributeName": "owningUserId",
-                "KeyType": "HASH",
-              },
-              {
-                "AttributeName": "createdAt",
-                "KeyType": "RANGE",
-              },
-            ],
-            "Projection": {
-              "ProjectionType": "ALL",
-            },
-          },
-        ],
         "KeySchema": [
           {
             "AttributeName": "shortUrlId",
@@ -1112,7 +1086,6 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "USERS_TABLE_NAME": {
               "Ref": "UsersTable9725E9C8",
             },
-            "USER_ID_GSI_NAME": "user-id-gsi",
           },
         },
         "FunctionName": "TestBackendStack-UserAPIsLambda",
@@ -1183,24 +1156,6 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
                 "Fn::GetAtt": [
                   "UsersTable9725E9C8",
                   "Arn",
-                ],
-              },
-            },
-            {
-              "Action": "dynamodb:Query",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "UrlsTable60368425",
-                        "Arn",
-                      ],
-                    },
-                    "/index/user-id-gsi",
-                  ],
                 ],
               },
             },


### PR DESCRIPTION
The GSI had `createdAt` instead of `createdTimestamp` for the sort key. I've updated the table to use `createdTimestamp` so when querying the index nothing came up. I tried to deploy the change but the GSI attributes aren't editable so the whole GSI must be deleted and re-created. Only one creation or deletion is allowed per deployment so we have to do this in two steps. A follow up PR will deploy the new GSI.