### PR TITLE
Add urlsTableOwningUserIdGsi

### DIFF
--- a/packages/infra/lib/backend-stack.ts
+++ b/packages/infra/lib/backend-stack.ts
@@ -38,13 +38,13 @@ export class BackendStack extends cdk.Stack {
       tableName: this.createResourceName("UrlsTable"),
     });
 
-    // const urlsTableOwningUserIdGsi = "GSI-owningUserId-createdTimestamp";
+    const urlsTableOwningUserIdGsi = "GSI-owningUserId-createdTimestamp";
 
-    // urlsTable.addGlobalSecondaryIndex({
-    //   indexName: urlsTableOwningUserIdGsi,
-    //   partitionKey: { name: "owningUserId", type: dynamodb.AttributeType.STRING },
-    //   sortKey: { name: "createdTimestamp", type: dynamodb.AttributeType.STRING },
-    // });
+    urlsTable.addGlobalSecondaryIndex({
+      indexName: urlsTableOwningUserIdGsi,
+      partitionKey: { name: "owningUserId", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "createdTimestamp", type: dynamodb.AttributeType.STRING },
+    });
 
     const usersTable = new dynamodb.Table(this, "UsersTable", {
       partitionKey: {
@@ -162,7 +162,7 @@ export class BackendStack extends cdk.Stack {
         environment: {
           URLS_TABLE_NAME: urlsTable.tableName,
           COUNT_BUCKETS_TABLE_NAME: countBucketsTable.tableName,
-          // USER_ID_GSI_NAME: urlsTableOwningUserIdGsi,
+          USER_ID_GSI_NAME: urlsTableOwningUserIdGsi,
           USERS_TABLE_NAME: usersTable.tableName,
         },
       },
@@ -171,10 +171,10 @@ export class BackendStack extends cdk.Stack {
       warming: true,
       policyStatements: [
         new PolicyStatement({ actions: ["dynamodb:GetItem"], resources: [usersTable.tableArn] }),
-        // new PolicyStatement({
-        //   actions: ["dynamodb:Query"],
-        //   resources: [`${urlsTable.tableArn}/index/${urlsTableOwningUserIdGsi}`],
-        // }),
+        new PolicyStatement({
+          actions: ["dynamodb:Query"],
+          resources: [`${urlsTable.tableArn}/index/${urlsTableOwningUserIdGsi}`],
+        }),
         new PolicyStatement({
           actions: ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:ConditionCheckItem"],
           resources: [countBucketsTable.tableArn, urlsTable.tableArn, usersTable.tableArn],

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -1047,8 +1047,34 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "AttributeName": "shortUrlId",
             "AttributeType": "S",
           },
+          {
+            "AttributeName": "owningUserId",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "createdTimestamp",
+            "AttributeType": "S",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "GSI-owningUserId-createdTimestamp",
+            "KeySchema": [
+              {
+                "AttributeName": "owningUserId",
+                "KeyType": "HASH",
+              },
+              {
+                "AttributeName": "createdTimestamp",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
+          },
+        ],
         "KeySchema": [
           {
             "AttributeName": "shortUrlId",
@@ -1086,6 +1112,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "USERS_TABLE_NAME": {
               "Ref": "UsersTable9725E9C8",
             },
+            "USER_ID_GSI_NAME": "GSI-owningUserId-createdTimestamp",
           },
         },
         "FunctionName": "TestBackendStack-UserAPIsLambda",
@@ -1156,6 +1183,24 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
                 "Fn::GetAtt": [
                   "UsersTable9725E9C8",
                   "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "dynamodb:Query",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "UrlsTable60368425",
+                        "Arn",
+                      ],
+                    },
+                    "/index/GSI-owningUserId-createdTimestamp",
+                  ],
                 ],
               },
             },


### PR DESCRIPTION
We removed a GSI that had the wrong attribute names in a previous PR, this one adds a new one with the correct attribute values. This GSI will be used for listing the URLs owned by a user.