### PR TITLE
Update handlers to return entire URL item

### DIFF
--- a/packages/lambda/src/handlers/user-apis-proxy/create-url.ts
+++ b/packages/lambda/src/handlers/user-apis-proxy/create-url.ts
@@ -16,6 +16,6 @@ export const createUrlForUser: AuthenticatedHandler = async (event) => {
   const { longUrl } = parseBody(event) as Body;
   if (!longUrl) throw new BadRequest("A longUrl must be provided in the request body");
 
-  const shortUrlId = await createShortUrl(longUrl, userId);
-  return response({ statusCode: 200, body: JSON.stringify({ shortUrlId }) });
+  const url = await createShortUrl(longUrl, userId);
+  return response({ statusCode: 200, body: JSON.stringify(url) });
 };


### PR DESCRIPTION
We're doing this so that on the frontend we can use SWR or React Query and update the local cache from these responses instead of making another call to get the new URL item.