### PR TITLE
Extract analytics serially once we know that the longUrl exists

### DIFF
--- a/packages/lambda/src/handlers/analytics-aggregator.ts
+++ b/packages/lambda/src/handlers/analytics-aggregator.ts
@@ -29,6 +29,8 @@ const updateUrlCount = async (shortUrlId: string, countIncrease: number): Promis
       new UpdateCommand({
         TableName: URLS_TABLE_NAME,
         Key: { shortUrlId },
+        // Ensures that we don't create a new item if it didn't already exist, we only update existing ones
+        ConditionExpression: "attribute_exists(shortUrlId)",
         UpdateExpression: "ADD totalVisits :increment",
         ExpressionAttributeValues: { ":increment": countIncrease },
       }),


### PR DESCRIPTION
I found some instances where the DynamoDB item didn't exist and we were publishing analytics events anyway. To fix this:

- We're now only publishing the analytics event after successfully fetching a `longUrl` (and also checking that the `longUrl` exists, not just the item).
- The aggregator now uses a condition expression to only update existing items, not create a new one if it doesn't exist.