### PR TITLE
Add `IS_PROD` env var to all Lambdas

### DIFF
--- a/packages/infra/bin/app.ts
+++ b/packages/infra/bin/app.ts
@@ -18,7 +18,10 @@ const devAndProdDomain = new DomainStack(app, "Domain-prod", {
 });
 
 // Stacks used for development and testing. These are deployed manually
-const devBackend = new BackendStack(app, "Backend-dev", { env: { account: ACCOUNT_ID, region: REGION } });
+const devBackend = new BackendStack(app, "Backend-dev", {
+  env: { account: ACCOUNT_ID, region: REGION },
+  isProd: false,
+});
 const devWebsite = new WebsiteStack(app, "Website-dev", {
   isProd: false,
   hostedZone: devAndProdDomain.hostedZone,

--- a/packages/infra/lib/constructs/api-route-lambda.ts
+++ b/packages/infra/lib/constructs/api-route-lambda.ts
@@ -14,6 +14,7 @@ export interface ApiRouteLambdaProps {
   lambdaProps: LlrtFunctionProps;
   path: string;
   methods: HttpMethod[];
+  isProd: boolean;
   warming?: boolean;
   policyStatements?: PolicyStatement[];
 }
@@ -24,7 +25,7 @@ export class ApiRouteLambda extends Construct {
   constructor(scope: Construct, id: string, props: ApiRouteLambdaProps) {
     super(scope, id);
 
-    const { httpApi, lambdaProps, path, methods, warming, policyStatements } = props;
+    const { httpApi, lambdaProps, path, methods, warming, policyStatements, isProd } = props;
 
     // Creating a custom log group so we can change retention, etc. if necessary
     const logGroup =
@@ -39,6 +40,10 @@ export class ApiRouteLambda extends Construct {
       logGroup,
       handler: "handler",
       ...lambdaProps,
+      environment: {
+        IS_PROD: isProd ? "true" : "false",
+        ...(lambdaProps.environment ?? {}),
+      },
     });
 
     policyStatements?.forEach((statement) => this.lambda.addToRolePolicy(statement));

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -51,6 +51,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "COUNT_BUCKETS_TABLE_NAME": {
               "Ref": "CountBucketsTable09F12BD0",
             },
+            "IS_PROD": "true",
             "URLS_TABLE_NAME": {
               "Ref": "UrlsTable60368425",
             },
@@ -224,6 +225,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
         "Environment": {
           "Variables": {
             "ANALYTICS_FIREHOSE_STREAM_NAME": "TestBackendStack-UrlAnalyticsFirehose",
+            "IS_PROD": "true",
             "URLS_TABLE_NAME": {
               "Ref": "UrlsTable60368425",
             },
@@ -1889,6 +1891,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "COUNT_BUCKETS_TABLE_NAME": {
               "Ref": "CountBucketsTable09F12BD0",
             },
+            "IS_PROD": "true",
             "URLS_TABLE_NAME": {
               "Ref": "UrlsTable60368425",
             },

--- a/packages/site/src/components/your-urls.tsx
+++ b/packages/site/src/components/your-urls.tsx
@@ -141,6 +141,7 @@ export const YourUrls = () => {
             <UrlCard />
           </>
         )}
+        {/* TODO: handle error state and add a toast maybe and then show no urls? */}
         {!urlsLoading && urls?.length === 0 && <NoUrls />}
       </div>
       {!urlsLoading && totalPages > 1 && (


### PR DESCRIPTION
The prod `UserAPIsLambda` is failing as it didn't have the `IS_PROD` env var defined. This PR sets it in the `ApiRouteLambda` construct instead of us needing to remember to set it for each Lambda.

### Testing

Deployed the dev stack and they all have `IS_PROD` set to `"false"`. The snapshot tests are right for the prod stack too.