### PR TITLE
Add remaining e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_Store
 .nx/cache
 .tmp
+test-results/

--- a/README.md
+++ b/README.md
@@ -2,16 +2,37 @@
 
 A URL shortener built for fun.
 
-### Development
+## Packages
 
-```text
+This is a monorepo managed with [Lerna](https://lerna.js.org/). Each package has its own README with detailed instructions:
+
+- [`site`](packages/site/): contains our site source code that builds a Next.js static site
+- [`lambda`](packages/lambda/): contains the Lambda handlers (user facing Lambdas use [LLRT](https://github.com/awslabs/llrt), others use Node.js)
+- [`infra`](packages/infra/): contains the code for our CDK stacks
+- [`e2e`](packages/e2e/): contains [Playwright](https://playwright.dev/docs/intro) end-to-end tests
+- [`types`](packages/types/): contains shared TypeScript types
+- [`shared`](packages/shared/): contains shared TypeScript utility functions
+
+## Getting started
+
+```bash
 npm ci
-npx lerna run build
-npx lerna run test
 ```
 
-See [`packages/infra/README.md`](packages/infra/README.md) for instructions on how to deploy the backend and website infrastructure.
+## Development
 
-### Deployment
+```bash
+npx lerna run build        # build all packages
+npx lerna run test         # run all unit tests
+npm run lint               # lint all packages
+```
 
-The [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) GitHub action deploys the prod CloudFormation stack when there is a push to the `main` branch.
+See each package's README for more commands (running the dev server, integration tests, deploying stacks, running e2e tests, etc.).
+
+## CI/CD
+
+The [`.github/workflows/ci.yml`](.github/workflows/ci.yml) workflow handles everything:
+
+1. Lints, runs unit tests, and runs integration tests. This is run on every PR and push to `main`.
+2. `dev` stacks are deployed on PRs, whereas `prod` stacks are deployed on push to `main`.
+3. E2E tests are run against the deployed environment after deployment.

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -37,3 +37,15 @@ npx playwright test --ui
 # Generate test code by recording actions
 npx playwright codegen dev.short.as
 ```
+
+## Cleanup
+
+Soft-delete leftover URLs created by the e2e test user if a test failed and it wasn't able to clean up after itself:
+
+```bash
+# Dev (default)
+./cleanup.sh
+
+# Prod
+./cleanup.sh prod
+```

--- a/packages/e2e/cleanup.sh
+++ b/packages/e2e/cleanup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Soft-delete all URLs owned by the e2e test user
+# Usage: ./cleanup.sh [dev|prod] [user-id]
+
+STAGE="${1:-dev}"
+TABLE="Backend-${STAGE}-UrlsTable"
+INDEX="GSI-owningUserId-createdTimestamp"
+REGION="eu-west-2"
+USER_ID="${2:-e2e-test-user}"
+
+ids=$(aws dynamodb query --region "$REGION" --no-cli-pager \
+  --table-name "$TABLE" \
+  --index-name "$INDEX" \
+  --key-condition-expression "owningUserId = :uid" \
+  --filter-expression "attribute_not_exists(isDeleted) OR isDeleted = :f" \
+  --expression-attribute-values "{\":uid\": {\"S\": \"$USER_ID\"}, \":f\": {\"BOOL\": false}}" \
+  --projection-expression "shortUrlId" \
+  --output json | python3 -c "
+import json, sys
+items = json.load(sys.stdin).get('Items', [])
+for item in items:
+    print(item['shortUrlId']['S'])
+")
+
+count=$(echo "$ids" | grep -c .)
+
+if [ "$count" -eq 0 ]; then
+  echo "No URLs found for $USER_ID in $TABLE"
+  exit 0
+fi
+
+echo "Soft-deleting $count URLs for $USER_ID in $TABLE..."
+
+for id in $ids; do
+  aws dynamodb update-item --region "$REGION" --no-cli-pager \
+    --table-name "$TABLE" \
+    --key "{\"shortUrlId\": {\"S\": \"$id\"}}" \
+    --update-expression "SET isDeleted = :d" \
+    --expression-attribute-values '{":d": {"BOOL": true}}'
+  echo "  deleted $id"
+done
+
+echo "Done"

--- a/packages/e2e/tests/logged-in.spec.ts
+++ b/packages/e2e/tests/logged-in.spec.ts
@@ -1,20 +1,71 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
+
+const shortenUrl = async (page: Page, longUrl: string) => {
+  await page.goto("/create/shorten");
+  await page.getByPlaceholder("Enter the URL to shorten").fill(longUrl);
+  await page.getByRole("button", { name: "Make it short as" }).click();
+  await expect(page.getByTestId("url-card").filter({ hasText: longUrl })).toBeVisible({ timeout: 10000 });
+};
+
+const urlCard = (page: Page, longUrl: string) => page.getByTestId("url-card").filter({ hasText: longUrl });
+
+const deleteUrl = async (page: Page, longUrl: string) => {
+  await urlCard(page, longUrl).locator("button[aria-haspopup='menu']").click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByText("URL deleted")).toBeVisible();
+};
 
 test("shorten a URL and see it in Your URLs", async ({ page }) => {
-  const uniqueUrl = `https://example.com/e2e-${Date.now()}`;
-  await page.goto("/create/shorten");
+  const uniqueUrl = `https://example.com/e2e-shorten-${Date.now()}`;
+  await shortenUrl(page, uniqueUrl);
 
-  await page.getByPlaceholder("Enter the URL to shorten").fill(uniqueUrl);
-  await page.getByRole("button", { name: "Make it short as" }).click();
-
-  // Logged in users stay on /create/shorten and the URL appears in the list below
   await expect(page.getByRole("heading", { name: "URLs" })).toBeVisible();
-  await expect(page.getByText(uniqueUrl)).toBeVisible({ timeout: 10000 });
 
-  await page.locator("button[aria-haspopup='menu']").first().click();
-  await page.getByText("Delete").click();
-  await page.getByRole("button", { name: "Delete" }).click();
-
-  await expect(page.getByText("URL deleted")).toBeVisible();
+  await deleteUrl(page, uniqueUrl);
   await expect(page.getByText(uniqueUrl)).not.toBeVisible();
+});
+
+test("edit a URL", async ({ page }) => {
+  const uniqueUrl = `https://example.com/e2e-edit-${Date.now()}`;
+  await shortenUrl(page, uniqueUrl);
+
+  await urlCard(page, uniqueUrl).locator("button[aria-haspopup='menu']").click();
+  await page.getByRole("menuitem", { name: "Edit" }).click();
+
+  await expect(page.getByLabel("Long URL")).not.toHaveValue("", { timeout: 10000 });
+
+  const updatedUrl = `https://example.com/e2e-edited-${Date.now()}`;
+  await page.getByLabel("Long URL").fill(updatedUrl);
+  await page.getByRole("button", { name: "Update" }).click();
+
+  await expect(page.getByText("URL updated")).toBeVisible();
+
+  await page.goto("/create/shorten");
+  await expect(page.getByText(updatedUrl)).toBeVisible({ timeout: 10000 });
+  await deleteUrl(page, updatedUrl);
+});
+
+test("analytics page loads", async ({ page }) => {
+  const uniqueUrl = `https://example.com/e2e-analytics-${Date.now()}`;
+  await shortenUrl(page, uniqueUrl);
+
+  await urlCard(page, uniqueUrl).locator("button[aria-haspopup='menu']").click();
+  await page.getByRole("menuitem", { name: "Analytics" }).click();
+
+  await expect(page.getByText("Region")).toBeVisible();
+  await expect(page.getByText("Country")).toBeVisible();
+  await expect(page.getByText("Device")).toBeVisible();
+  await expect(page.getByText("Referer")).toBeVisible();
+
+  await page.goto("/create/shorten");
+  await expect(page.getByText(uniqueUrl)).toBeVisible({ timeout: 10000 });
+  await deleteUrl(page, uniqueUrl);
+});
+
+test("profile page loads", async ({ page }) => {
+  await page.goto("/create/profile");
+
+  await expect(page.getByText("E2E Test User")).toBeVisible();
+  await expect(page.getByText("e2e@test.local")).toBeVisible();
 });

--- a/packages/e2e/tests/logged-out.spec.ts
+++ b/packages/e2e/tests/logged-out.spec.ts
@@ -9,3 +9,30 @@ test("shorten a URL", async ({ page }) => {
   await expect(page.getByText("Wow, that really is")).toBeVisible();
   await expect(page.getByText("Short.as URL")).toBeVisible();
 });
+
+test("short URL redirects to long URL", async ({ page, request }) => {
+  await page.goto("/create/shorten");
+
+  const longUrl = "https://example.com";
+  await page.getByPlaceholder("Enter the URL to shorten").fill(longUrl);
+  await page.getByRole("button", { name: "Make it short as" }).click();
+
+  await expect(page.getByText("Short.as URL")).toBeVisible();
+
+  const shortUrlText = await page.getByText(/short\.as\//).textContent();
+  const shortUrlId = shortUrlText?.split("/").pop();
+
+  const baseURL = process.env.BASE_URL || "https://dev.short.as";
+  const response = await request.fetch(`${baseURL}/${shortUrlId}`, { maxRedirects: 0 });
+  expect(response.status()).toBe(302);
+  expect(response.headers()["location"]).toBe(longUrl);
+});
+
+test("login page shows OAuth buttons", async ({ page }) => {
+  await page.goto("/create/login");
+
+  await expect(page.getByText("Welcome to short.as")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Continue with Google" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Continue with Facebook" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Continue with GitHub" })).toBeVisible();
+});

--- a/packages/site/src/components/your-urls.tsx
+++ b/packages/site/src/components/your-urls.tsx
@@ -37,7 +37,7 @@ const UrlCard = ({ url }: UrlCardProps) => {
   }, [isCopied]);
 
   return (
-    <Card>
+    <Card data-testid="url-card">
       <CardContent className="px-4 sm:px-5 py-4 sm:py-5">
         <div className="grid grid-cols-12 gap-1 sm:gap-4 items-center">
           {/* Column 1: Short + long URL */}


### PR DESCRIPTION
- Updated the `README.md` to include information about our packages
- Added a script to allow for soft deleting URLs from failed end to end tests
- Added the remaining end to end tests:
  - Short URL redirect: shortens a URL, extracts the short ID, verifies that a `302` status code and 
`Location` header is returned
  - Login page: checks that the Google, Facebook, and GitHub OAuth buttons are visible
  - Edit: shortens a URL, opens the edit page via the options menu, changes the long URL, 
verifies the "URL updated" toast
  - Analytics: shortens a URL, opens the analytics page via the options menu, verifies the 
breakdown cards load
  - Profile: navigates to the profile page, verifies that the test user's name and email are visible