### PR TITLE
Fix daily and weekly analytics ticks

### DIFF
--- a/packages/site/src/app/analytics/page.tsx
+++ b/packages/site/src/app/analytics/page.tsx
@@ -273,22 +273,23 @@ const generateTicks = (from: Date, to: Date, period: Period): string[] => {
   const ticks: string[] = [];
   const current = new Date(from);
 
+  // Use UTC methods so ticks align with the backend's UTC-based aggregation keys
   if (period === "hour") {
-    current.setMinutes(0, 0, 0);
+    current.setUTCMinutes(0, 0, 0);
   } else if (period === "day") {
-    current.setHours(0, 0, 0, 0);
+    current.setUTCHours(0, 0, 0, 0);
   } else {
-    current.setHours(0, 0, 0, 0);
-    // Roll back to Monday. getDay() returns 0 for Sunday, 1 for Monday, etc.
+    current.setUTCHours(0, 0, 0, 0);
+    // Roll back to Monday. getUTCDay() returns 0 for Sunday, 1 for Monday, etc.
     // (day + 6) % 7 gives how many days to subtract: Mon=0, Tue=1, ..., Sun=6
-    current.setDate(current.getDate() - ((current.getDay() + 6) % 7));
+    current.setUTCDate(current.getUTCDate() - ((current.getUTCDay() + 6) % 7));
   }
 
   while (current <= to) {
     ticks.push(current.toISOString());
-    if (period === "hour") current.setHours(current.getHours() + 1);
-    else if (period === "day") current.setDate(current.getDate() + 1);
-    else current.setDate(current.getDate() + 7);
+    if (period === "hour") current.setUTCHours(current.getUTCHours() + 1);
+    else if (period === "day") current.setUTCDate(current.getUTCDate() + 1);
+    else current.setUTCDate(current.getUTCDate() + 7);
   }
 
   return ticks;


### PR DESCRIPTION
An attempt to fix https://github.com/ainsleyrutterford/short.as/issues/76

The backend aggregates analytics into time buckets keyed by UTC timestamps (e.g. `day_gRKZkXM` with `sk: "2026-04-13T00:00:00.000Z"`). The frontend's `generateTicks` function creates the x axis ticks for the chart, then matches them against the backend data by ISO string equality.

Previously, `generateTicks` used local time methods (`setHours`, `setDate`, `getDay`) to align ticks to period boundaries. When `.toISOString()` converts these to UTC, they shift by the user's timezone offset.

For example, for me in BST, a "day" tick at local midnight would be `2026-04-12T23:00:00.000Z`, which doesn't match the backend's `2026-04-13T00:00:00.000Z`. The data exists in the response but the chart shows `0` because the map lookup fails.

The fix switches to UTC date methods (`setUTCHours`, `setUTCDate`, `getUTCDay`) so the generated ticks align with the backend's aggregation keys, regardless of the user's local timezone.