### PR TITLE
Add TXT record for Google domain verification

### DIFF
--- a/packages/infra/lib/domain-stack.ts
+++ b/packages/infra/lib/domain-stack.ts
@@ -40,6 +40,13 @@ export class DomainStack extends cdk.Stack {
       domainName: this.hostedZone.zoneName,
     });
 
+    // Verifies to Google that we own this domain. See:
+    // https://knowledge.workspace.google.com/admin/domains/verify-your-domain-with-a-txt-record
+    new route53.TxtRecord(this, "GoogleTxtRecord", {
+      zone: this.hostedZone,
+      values: ["google-site-verification=rPIYoTNgOW83x0Ra3zVEnCTWXCs-Xogrw4_kLljhQew"],
+    });
+
     this.certificate = new acm.Certificate(this, "Certificate", {
       domainName: "short.as",
       subjectAlternativeNames: ["www.short.as"],


### PR DESCRIPTION
Part of https://github.com/ainsleyrutterford/short.as/issues/75

Our Google OAuth branding verification failed for the prod and dev as we need to verify we own the domain. So following [these steps](https://support.google.com/cloud/answer/13807376#zippy=%2Cthe-website-you-provided-as-your-homepage-is-not-registered-to-you) to verify.

(Also I was paranoid about committing this but it can be public: https://security.stackexchange.com/questions/265957/are-site-verification-tokens-secret)