### PR TITLE
Show login link on prod

### DIFF
--- a/packages/site/src/app/shorten/page.tsx
+++ b/packages/site/src/app/shorten/page.tsx
@@ -14,7 +14,6 @@ import { useAuth } from "@/contexts/auth";
 import { LoadingSpinner } from "@/components/ui/loading";
 import { CreateAccountSuggestion } from "@/components/create-account-suggestion";
 import { PageContainer } from "@/components/page-container";
-import { isProd } from "@/lib/utils";
 import { YourUrls } from "@/components/your-urls";
 import { useAddUrl } from "@/queries/urls";
 import { useUrlInput } from "@/hooks/use-url-input";
@@ -145,8 +144,7 @@ const ShortenPage = () => {
           </form>
         </Card>
         {isLoggedInLoaded && loggedIn && <YourUrls />}
-        {/* For now, only show login for dev */}
-        {isLoggedInLoaded && !isProd && !loggedIn && <CreateAccountSuggestion />}
+        {isLoggedInLoaded && !loggedIn && <CreateAccountSuggestion />}
       </div>
     </PageContainer>
   );


### PR DESCRIPTION
Closes https://github.com/ainsleyrutterford/short.as/issues/75

Finally done! We have working login with Google, Microsoft, and GitHub for Prod.

- With Google we have a verified and published app (and verified our `short.as` domain).
- With Microsoft we have verified the domain but can't get an MPN ID since we aren't an organisation. We should still have unlimited users the only downside is it shows an unverified app warning and some users in business contexts will need admins to aprove :/
- With GitHub it's unlimited users and no verification needed!