### PR TITLE
Fix colour picker popover closing on first click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8989,9 +8989,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/site/src/components/qr-code.tsx
+++ b/packages/site/src/components/qr-code.tsx
@@ -177,7 +177,9 @@ const ColorInput = ({ hsva, setHsva }: { hsva: HSVA; setHsva: React.Dispatch<Rea
 
   return (
     <div className="flex gap-1">
-      <Popover open={open} onOpenChange={setOpen}>
+      {/* modal prevents Dialog's DismissableLayer from closing the Popover on click.
+         See: https://github.com/shadcn-ui/ui/issues/10469 */}
+      <Popover open={open} onOpenChange={setOpen} modal>
         <PopoverTrigger asChild>
           <Button
             variant="outline"
@@ -188,23 +190,7 @@ const ColorInput = ({ hsva, setHsva }: { hsva: HSVA; setHsva: React.Dispatch<Rea
             <Pipette className="h-4 w-4" style={{ color: isDark(hsva) ? "white" : "black" }} />
           </Button>
         </PopoverTrigger>
-        {/* 
-          usePortal={false} is needed for Popovers inside Dialog/Drawer to work properly.
-          See: https://stackoverflow.com/questions/79425374
-          
-          forceMount + display:none keeps Colorful mounted so its event handlers are registered
-          before the first interaction. Without this, the first click closes the Popover because
-          Colorful's handlers aren't set up yet and Radix treats it as an outside click.
-        */}
-        <PopoverContent
-          className="w-fit"
-          side="top"
-          align="start"
-          avoidCollisions={false}
-          usePortal={false}
-          forceMount
-          style={{ display: open ? undefined : "none" }}
-        >
+        <PopoverContent className="w-fit" side="top" align="start" avoidCollisions={false}>
           <div className="flex flex-col gap-3">
             <Colorful color={hsva} onChange={(color) => setHsva(color.hsva)} />
             <div className="flex flex-row gap-3">


### PR DESCRIPTION
Recently I've noticed the colour picker just doesn't work at all. We have loads of props leftover from when I was tackling a problem where the colour picker `Popover` inside the QR code Dialog was closing immediately on the first click. This was caused by Radix's `DismissableLayer` in the Dialog treating clicks inside the Popover as "outside" interactions.

The previous workaround (`usePortal={false}` + `forceMount` + `display:none`) no longer works with `@radix-ui/react-dialog 1.1.15` (upgraded from `1.1.4`).

This attempted fix is adding `modal` to the `Popover` root, which gives it its own `DismissableLayer` context that the Dialog won't interfere with. It works on localhost and deployed to dev.short.as and it works on Firefox and iOS Safari.

See: https://github.com/shadcn-ui/ui/issues/10469