### PR TITLE
Add monitoring dashboard, alarms, and cost circuit breaker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7706,8 +7706,16 @@
       "resolved": "packages/lambda",
       "link": true
     },
+    "node_modules/@short-as/shared": {
+      "resolved": "packages/shared",
+      "link": true
+    },
     "node_modules/@short-as/site": {
       "resolved": "packages/site",
+      "link": true
+    },
+    "node_modules/@short-as/types": {
+      "resolved": "packages/types",
       "link": true
     },
     "node_modules/@sigstore/bundle": {
@@ -25982,6 +25990,7 @@
         "@aws-cdk/aws-glue-alpha": "^2.206.0-alpha.0",
         "@short-as/lambda": "*",
         "@short-as/site": "*",
+        "@short-as/types": "*",
         "aws-cdk-lib": "^2.191.0",
         "cdk-lambda-llrt": "^0.0.15",
         "constructs": "^10.0.0",
@@ -26112,6 +26121,8 @@
         "@aws-sdk/lib-dynamodb": "^3.525.0",
         "@middy/http-error-handler": "^6.3.0",
         "@middy/http-router": "^6.3.1",
+        "@short-as/shared": "*",
+        "@short-as/types": "*",
         "arctic": "^3.7.0",
         "cookie": "^1.0.2",
         "jsrsasign": "^11.1.0",
@@ -26122,6 +26133,7 @@
         "@types/aws-lambda": "^8.10.149",
         "@types/jest": "^30.0.0",
         "@types/jsrsasign": "^10.5.15",
+        "@types/node": "^24.0.0",
         "esbuild": "^0.27.1",
         "jest": "^30.3.0",
         "ts-jest": "^29.4.6"
@@ -27230,6 +27242,10 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "packages/shared": {
+      "name": "@short-as/shared",
+      "version": "0.0.1"
+    },
     "packages/site": {
       "name": "@short-as/site",
       "version": "0.1.0",
@@ -27248,6 +27264,8 @@
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tooltip": "^1.0.7",
+        "@short-as/shared": "*",
+        "@short-as/types": "*",
         "@tanstack/react-query": "^5.85.3",
         "@types/mdx": "^2.0.13",
         "@uiw/react-color-colorful": "^2.9.5",
@@ -27285,6 +27303,10 @@
         "tailwind-scrollbar": "^3.1.0",
         "tailwindcss": "^3.3.0"
       }
+    },
+    "packages/types": {
+      "name": "@short-as/types",
+      "version": "0.0.1"
     }
   }
 }

--- a/packages/infra/lib/backend-stack.ts
+++ b/packages/infra/lib/backend-stack.ts
@@ -219,7 +219,7 @@ export class BackendStack extends cdk.Stack {
       lambdas: [createShortUrl.lambda, getLongUrl.lambda, oauth.lambda, userApis.lambda, analyticsAggregator.lambda],
       tables: [urlsTable, countBucketsTable, usersTable, analyticsAggregator.analyticsAggregationTable],
       deliveryStream: analyticsAggregator.deliveryStream,
-      alarmEmail: isProd ? "ainsley.rutterford@gmail.com" : undefined,
+      alarmEmail: "ainsley.rutterford@gmail.com",
     });
   }
 

--- a/packages/infra/lib/backend-stack.ts
+++ b/packages/infra/lib/backend-stack.ts
@@ -8,6 +8,7 @@ import { PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { ApiRouteLambda } from "./constructs/api-route-lambda";
 import { UrlAnalyticsAggregator } from "./constructs/analytics-aggregator";
+import { Monitoring } from "./constructs/monitoring";
 
 interface BackendStackProps extends cdk.StackProps {
   isProd: boolean;
@@ -92,7 +93,7 @@ export class BackendStack extends cdk.Stack {
       resources: [`arn:aws:ssm:${region}:${account}:parameter/${isProd ? "prod" : "dev"}/oauth/*`],
     });
 
-    new ApiRouteLambda(this, "CreateShortUrlLambda", {
+    const createShortUrl = new ApiRouteLambda(this, "CreateShortUrlLambda", {
       httpApi: this.httpApi,
       lambdaProps: {
         // This filepath is relative to the root of the infra package I believe
@@ -118,7 +119,7 @@ export class BackendStack extends cdk.Stack {
       ],
     });
 
-    new ApiRouteLambda(this, "GetLongUrlLambda", {
+    const getLongUrl = new ApiRouteLambda(this, "GetLongUrlLambda", {
       httpApi: this.httpApi,
       lambdaProps: {
         entry: "../lambda/src/handlers/get-long-url.ts",
@@ -148,7 +149,7 @@ export class BackendStack extends cdk.Stack {
       ],
     });
 
-    new ApiRouteLambda(this, "OAuthLambda", {
+    const oauth = new ApiRouteLambda(this, "OAuthLambda", {
       httpApi: this.httpApi,
       lambdaProps: {
         entry: "../lambda/src/handlers/oauth-proxy.ts",
@@ -170,7 +171,7 @@ export class BackendStack extends cdk.Stack {
       ],
     });
 
-    new ApiRouteLambda(this, "UserAPIsLambda", {
+    const userApis = new ApiRouteLambda(this, "UserAPIsLambda", {
       httpApi: this.httpApi,
       lambdaProps: {
         entry: "../lambda/src/handlers/user-apis-proxy/index.ts",
@@ -210,6 +211,15 @@ export class BackendStack extends cdk.Stack {
         }),
         getOAuthSSMParameterStatement,
       ],
+    });
+
+    new Monitoring(this, "Monitoring", {
+      isProd,
+      httpApi: this.httpApi,
+      lambdas: [createShortUrl.lambda, getLongUrl.lambda, oauth.lambda, userApis.lambda, analyticsAggregator.lambda],
+      tables: [urlsTable, countBucketsTable, usersTable, analyticsAggregator.analyticsAggregationTable],
+      deliveryStream: analyticsAggregator.deliveryStream,
+      alarmEmail: isProd ? "ainsley.rutterford@gmail.com" : undefined,
     });
   }
 

--- a/packages/infra/lib/constructs/analytics-aggregator.ts
+++ b/packages/infra/lib/constructs/analytics-aggregator.ts
@@ -16,6 +16,7 @@ export interface UrlAnalyticsAggregatorProps {
 export class UrlAnalyticsAggregator extends Construct {
   public deliveryStream: firehose.CfnDeliveryStream;
   public analyticsAggregationTable: dynamodb.Table;
+  public lambda: lambda.IFunction;
   private stackName: string;
 
   constructor(scope: Construct, id: string, props: UrlAnalyticsAggregatorProps) {
@@ -52,6 +53,8 @@ export class UrlAnalyticsAggregator extends Construct {
       },
       timeout: Duration.seconds(120),
     });
+
+    this.lambda = aggregatorLambda;
 
     this.analyticsAggregationTable.grantReadWriteData(aggregatorLambda);
     urlsTable.grantReadWriteData(aggregatorLambda);

--- a/packages/infra/lib/constructs/analytics-aggregator.ts
+++ b/packages/infra/lib/constructs/analytics-aggregator.ts
@@ -16,7 +16,7 @@ export interface UrlAnalyticsAggregatorProps {
 export class UrlAnalyticsAggregator extends Construct {
   public deliveryStream: firehose.CfnDeliveryStream;
   public analyticsAggregationTable: dynamodb.Table;
-  public lambda: lambda.IFunction;
+  public lambda: lambda.Function;
   private stackName: string;
 
   constructor(scope: Construct, id: string, props: UrlAnalyticsAggregatorProps) {

--- a/packages/infra/lib/constructs/monitoring.ts
+++ b/packages/infra/lib/constructs/monitoring.ts
@@ -1,0 +1,276 @@
+import { Construct } from "constructs";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
+import * as actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Duration } from "aws-cdk-lib";
+import { HttpApi } from "aws-cdk-lib/aws-apigatewayv2";
+import { IFunction } from "aws-cdk-lib/aws-lambda";
+import { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+
+export interface MonitoringProps {
+  isProd: boolean;
+  httpApi: HttpApi;
+  lambdas: IFunction[];
+  tables: ITable[];
+  deliveryStream: CfnDeliveryStream;
+  alarmEmail?: string;
+}
+
+export class Monitoring extends Construct {
+  private readonly alarmAction?: actions.SnsAction;
+  private readonly alarms: cloudwatch.Alarm[] = [];
+  private readonly period = Duration.minutes(15);
+
+  constructor(scope: Construct, id: string, props: MonitoringProps) {
+    super(scope, id);
+
+    const { httpApi, lambdas, tables, deliveryStream } = props;
+
+    if (props.isProd && props.alarmEmail) {
+      const topic = new sns.Topic(this, "AlarmTopic", { topicName: "short-as-alarms" });
+      topic.addSubscription(new subscriptions.EmailSubscription(props.alarmEmail));
+      this.alarmAction = new actions.SnsAction(topic);
+    }
+
+    this.addApiGatewayAlarms(httpApi);
+    this.addLambdaAlarms(lambdas);
+    this.addDynamoDbAlarms(tables);
+    this.addFirehoseAlarms(deliveryStream);
+
+    const dashboard = new cloudwatch.Dashboard(this, "Dashboard", {
+      dashboardName: `short-as-${props.isProd ? "prod" : "dev"}`,
+      defaultInterval: Duration.days(14),
+    });
+
+    dashboard.addWidgets(new cloudwatch.AlarmStatusWidget({ alarms: this.alarms, width: 24, title: "Alarm Status" }));
+
+    this.addApiGatewayWidgets(dashboard, httpApi);
+    this.addLambdaWidgets(dashboard, lambdas);
+    this.addDynamoDbWidgets(dashboard, tables);
+    this.addFirehoseWidgets(dashboard, deliveryStream);
+  }
+
+  private addApiGatewayWidgets(dashboard: cloudwatch.Dashboard, httpApi: HttpApi) {
+    const dims = { ApiId: httpApi.httpApiId };
+
+    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## API Gateway", width: 24, height: 1 }));
+
+    dashboard.addWidgets(
+      new cloudwatch.GraphWidget({
+        title: "Requests & Errors",
+        left: [
+          new cloudwatch.Metric({
+            namespace: "AWS/ApiGateway",
+            metricName: "Count",
+            dimensionsMap: dims,
+            statistic: "Sum",
+            label: "Requests",
+          }),
+          new cloudwatch.Metric({
+            namespace: "AWS/ApiGateway",
+            metricName: "5xx",
+            dimensionsMap: dims,
+            statistic: "Sum",
+            label: "5xx",
+          }),
+          new cloudwatch.Metric({
+            namespace: "AWS/ApiGateway",
+            metricName: "4xx",
+            dimensionsMap: dims,
+            statistic: "Sum",
+            label: "4xx",
+          }),
+        ],
+        width: 24,
+      }),
+    );
+  }
+
+  private addLambdaWidgets(dashboard: cloudwatch.Dashboard, lambdas: IFunction[]) {
+    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## Lambda", width: 24, height: 1 }));
+
+    const widgets = lambdas.map(
+      (fn) =>
+        new cloudwatch.GraphWidget({
+          title: fn.functionName,
+          left: [fn.metricInvocations({ statistic: "Sum" }), fn.metricErrors({ statistic: "Sum" })],
+          width: 8,
+        }),
+    );
+    dashboard.addWidgets(...widgets);
+  }
+
+  private addDynamoDbWidgets(dashboard: cloudwatch.Dashboard, tables: ITable[]) {
+    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## DynamoDB", width: 24, height: 1 }));
+
+    const widgets = tables.map(
+      (table) =>
+        new cloudwatch.GraphWidget({
+          title: table.tableName,
+          left: [
+            new cloudwatch.Metric({
+              namespace: "AWS/DynamoDB",
+              metricName: "ThrottledRequests",
+              dimensionsMap: { TableName: table.tableName },
+              statistic: "Sum",
+              label: "Throttled",
+            }),
+            new cloudwatch.Metric({
+              namespace: "AWS/DynamoDB",
+              metricName: "SystemErrors",
+              dimensionsMap: { TableName: table.tableName },
+              statistic: "Sum",
+              label: "System Errors",
+            }),
+          ],
+          width: 8,
+        }),
+    );
+    dashboard.addWidgets(...widgets);
+  }
+
+  private addFirehoseWidgets(dashboard: cloudwatch.Dashboard, deliveryStream: CfnDeliveryStream) {
+    const dims = { DeliveryStreamName: deliveryStream.ref };
+
+    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## Firehose", width: 24, height: 1 }));
+
+    dashboard.addWidgets(
+      new cloudwatch.GraphWidget({
+        title: "Incoming Records",
+        left: [
+          new cloudwatch.Metric({
+            namespace: "AWS/Firehose",
+            metricName: "IncomingRecords",
+            dimensionsMap: dims,
+            statistic: "Sum",
+          }),
+        ],
+        width: 12,
+      }),
+      new cloudwatch.GraphWidget({
+        title: "Delivery Freshness",
+        left: [
+          new cloudwatch.Metric({
+            namespace: "AWS/Firehose",
+            metricName: "DeliveryToS3.DataFreshness",
+            dimensionsMap: dims,
+            statistic: "Maximum",
+          }),
+        ],
+        width: 12,
+      }),
+    );
+  }
+
+  private addApiGatewayAlarms(httpApi: HttpApi) {
+    const dims = { ApiId: httpApi.httpApiId };
+    const period = this.period;
+
+    const requests = new cloudwatch.Metric({
+      namespace: "AWS/ApiGateway",
+      metricName: "Count",
+      dimensionsMap: dims,
+      statistic: "Sum",
+      period,
+    });
+
+    this.addRateAlarm("ApiGateway5xxRate", {
+      errors: new cloudwatch.Metric({
+        namespace: "AWS/ApiGateway",
+        metricName: "5xx",
+        dimensionsMap: dims,
+        statistic: "Sum",
+        period,
+      }),
+      total: requests,
+      floor: 5,
+      threshold: 10,
+    });
+
+    this.addRateAlarm("ApiGateway4xxRate", {
+      errors: new cloudwatch.Metric({
+        namespace: "AWS/ApiGateway",
+        metricName: "4xx",
+        dimensionsMap: dims,
+        statistic: "Sum",
+        period,
+      }),
+      total: requests,
+      floor: 10,
+      threshold: 30,
+    });
+  }
+
+  private addLambdaAlarms(lambdas: IFunction[]) {
+    const period = this.period;
+
+    for (const fn of lambdas) {
+      const id = fn.node.scope?.node.id ?? fn.node.id;
+      this.addRateAlarm(`${id}-ErrorRate`, {
+        errors: fn.metricErrors({ statistic: "Sum", period }),
+        total: fn.metricInvocations({ statistic: "Sum", period }),
+        floor: 5,
+        threshold: 10,
+      });
+    }
+  }
+
+  private addDynamoDbAlarms(tables: ITable[]) {
+    for (const table of tables) {
+      this.addAlarm(
+        `${table.node.id}-Throttled`,
+        new cloudwatch.Metric({
+          namespace: "AWS/DynamoDB",
+          metricName: "ThrottledRequests",
+          dimensionsMap: { TableName: table.tableName },
+          statistic: "Sum",
+          period: Duration.minutes(5),
+        }),
+        0,
+      );
+    }
+  }
+
+  private addFirehoseAlarms(deliveryStream: CfnDeliveryStream) {
+    this.addAlarm(
+      "FirehoseFreshness",
+      new cloudwatch.Metric({
+        namespace: "AWS/Firehose",
+        metricName: "DeliveryToS3.DataFreshness",
+        dimensionsMap: { DeliveryStreamName: deliveryStream.ref },
+        statistic: "Maximum",
+        period: this.period,
+      }),
+      900,
+    );
+  }
+
+  private addRateAlarm(
+    id: string,
+    opts: { errors: cloudwatch.IMetric; total: cloudwatch.IMetric; floor: number; threshold: number },
+  ) {
+    const rate = new cloudwatch.MathExpression({
+      expression: `IF(total > ${opts.floor}, errors / total * 100, 0)`,
+      usingMetrics: { total: opts.total, errors: opts.errors },
+      label: `${id} (%)`,
+      period: this.period,
+    });
+
+    this.addAlarm(id, rate, opts.threshold);
+  }
+
+  private addAlarm(id: string, metric: cloudwatch.IMetric, threshold: number) {
+    const alarm = new cloudwatch.Alarm(this, id, {
+      metric,
+      threshold,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    if (this.alarmAction) alarm.addAlarmAction(this.alarmAction);
+    this.alarms.push(alarm);
+  }
+}

--- a/packages/infra/lib/constructs/monitoring.ts
+++ b/packages/infra/lib/constructs/monitoring.ts
@@ -5,11 +5,22 @@ import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
 import * as actions from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as budgets from "aws-cdk-lib/aws-budgets";
+import * as events from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as nodeJsLambda from "aws-cdk-lib/aws-lambda-nodejs";
 import { Duration, Stack } from "aws-cdk-lib";
 import { HttpApi } from "aws-cdk-lib/aws-apigatewayv2";
 import { Function } from "aws-cdk-lib/aws-lambda";
 import { ITable } from "aws-cdk-lib/aws-dynamodb";
 import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { OAuthProvider } from "@short-as/types";
+
+const NAMESPACE = "short.as";
+
+const sectionHeader = (title: string) => new cloudwatch.TextWidget({ markdown: `## ${title}`, width: 24, height: 1 });
+
+const lambdaId = (fn: Function) => fn.node.scope?.node.id ?? fn.node.id;
 
 export interface MonitoringProps {
   isProd: boolean;
@@ -30,7 +41,7 @@ export class Monitoring extends Construct {
 
     const { httpApi, lambdas, tables, deliveryStream } = props;
 
-    if (props.isProd && props.alarmEmail) {
+    if (props.isProd) {
       const topic = new sns.Topic(this, "AlarmTopic", { topicName: "short-as-alarms" });
       topic.addSubscription(new subscriptions.EmailSubscription(props.alarmEmail));
       this.alarmAction = new actions.SnsAction(topic);
@@ -41,6 +52,7 @@ export class Monitoring extends Construct {
     this.addDynamoDbAlarms(tables);
     this.addFirehoseAlarms(deliveryStream);
     this.addCostCircuitBreaker(props);
+    this.addBusinessMetrics(props);
 
     const dashboard = new cloudwatch.Dashboard(this, "Dashboard", {
       dashboardName: `short-as-${props.isProd ? "prod" : "dev"}`,
@@ -53,92 +65,76 @@ export class Monitoring extends Construct {
     this.addLambdaWidgets(dashboard, lambdas);
     this.addDynamoDbWidgets(dashboard, tables);
     this.addFirehoseWidgets(dashboard, deliveryStream);
+    this.addBusinessMetricsWidgets(dashboard, tables);
   }
 
   private addApiGatewayWidgets(dashboard: cloudwatch.Dashboard, httpApi: HttpApi) {
-    const dims = { ApiId: httpApi.httpApiId };
+    const metric = (metricName: string, label: string) =>
+      new cloudwatch.Metric({
+        namespace: "AWS/ApiGateway",
+        metricName,
+        dimensionsMap: { ApiId: httpApi.httpApiId },
+        statistic: "Sum",
+        label,
+      });
 
-    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## API Gateway", width: 24, height: 1 }));
-
+    dashboard.addWidgets(sectionHeader("API Gateway"));
     dashboard.addWidgets(
       new cloudwatch.GraphWidget({
         title: "Requests & Errors",
-        left: [
-          new cloudwatch.Metric({
-            namespace: "AWS/ApiGateway",
-            metricName: "Count",
-            dimensionsMap: dims,
-            statistic: "Sum",
-            label: "Requests",
-          }),
-          new cloudwatch.Metric({
-            namespace: "AWS/ApiGateway",
-            metricName: "5xx",
-            dimensionsMap: dims,
-            statistic: "Sum",
-            label: "5xx",
-          }),
-          new cloudwatch.Metric({
-            namespace: "AWS/ApiGateway",
-            metricName: "4xx",
-            dimensionsMap: dims,
-            statistic: "Sum",
-            label: "4xx",
-          }),
-        ],
+        left: [metric("Count", "Requests"), metric("5xx", "5xx"), metric("4xx", "4xx")],
         width: 24,
       }),
     );
   }
 
   private addLambdaWidgets(dashboard: cloudwatch.Dashboard, lambdas: Function[]) {
-    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## Lambda", width: 24, height: 1 }));
-
-    const widgets = lambdas.map(
-      (fn) =>
-        new cloudwatch.GraphWidget({
-          title: fn.functionName,
-          left: [fn.metricInvocations({ statistic: "Sum" }), fn.metricErrors({ statistic: "Sum" })],
-          width: 8,
-        }),
+    dashboard.addWidgets(sectionHeader("Lambda"));
+    dashboard.addWidgets(
+      ...lambdas.map(
+        (fn) =>
+          new cloudwatch.GraphWidget({
+            title: fn.functionName,
+            left: [fn.metricInvocations({ statistic: "Sum" }), fn.metricErrors({ statistic: "Sum" })],
+            width: 8,
+          }),
+      ),
     );
-    dashboard.addWidgets(...widgets);
   }
 
   private addDynamoDbWidgets(dashboard: cloudwatch.Dashboard, tables: ITable[]) {
-    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## DynamoDB", width: 24, height: 1 }));
-
-    const widgets = tables.map(
-      (table) =>
-        new cloudwatch.GraphWidget({
-          title: table.tableName,
-          left: [
-            new cloudwatch.Metric({
-              namespace: "AWS/DynamoDB",
-              metricName: "ThrottledRequests",
-              dimensionsMap: { TableName: table.tableName },
-              statistic: "Sum",
-              label: "Throttled",
-            }),
-            new cloudwatch.Metric({
-              namespace: "AWS/DynamoDB",
-              metricName: "SystemErrors",
-              dimensionsMap: { TableName: table.tableName },
-              statistic: "Sum",
-              label: "System Errors",
-            }),
-          ],
-          width: 8,
-        }),
+    dashboard.addWidgets(sectionHeader("DynamoDB"));
+    dashboard.addWidgets(
+      ...tables.map(
+        (table) =>
+          new cloudwatch.GraphWidget({
+            title: table.tableName,
+            left: [
+              new cloudwatch.Metric({
+                namespace: "AWS/DynamoDB",
+                metricName: "ThrottledRequests",
+                dimensionsMap: { TableName: table.tableName },
+                statistic: "Sum",
+                label: "Throttled",
+              }),
+              new cloudwatch.Metric({
+                namespace: "AWS/DynamoDB",
+                metricName: "SystemErrors",
+                dimensionsMap: { TableName: table.tableName },
+                statistic: "Sum",
+                label: "System Errors",
+              }),
+            ],
+            width: 8,
+          }),
+      ),
     );
-    dashboard.addWidgets(...widgets);
   }
 
   private addFirehoseWidgets(dashboard: cloudwatch.Dashboard, deliveryStream: CfnDeliveryStream) {
     const dims = { DeliveryStreamName: deliveryStream.ref };
 
-    dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## Firehose", width: 24, height: 1 }));
-
+    dashboard.addWidgets(sectionHeader("Firehose"));
     dashboard.addWidgets(
       new cloudwatch.GraphWidget({
         title: "Incoming Records",
@@ -167,53 +163,59 @@ export class Monitoring extends Construct {
     );
   }
 
+  private addBusinessMetricsWidgets(dashboard: cloudwatch.Dashboard, tables: ITable[]) {
+    dashboard.addWidgets(sectionHeader("Business Metrics"));
+    dashboard.addWidgets(
+      ...tables.map(
+        (table) =>
+          new cloudwatch.GraphWidget({
+            title: `${table.tableName} Items`,
+            left: [
+              new cloudwatch.Metric({
+                namespace: NAMESPACE,
+                metricName: "ItemCount",
+                dimensionsMap: { TableName: table.tableName },
+                statistic: "Maximum",
+              }),
+            ],
+            width: 8,
+          }),
+      ),
+    );
+
+    const loginMetrics = Object.values(OAuthProvider).map(
+      (provider) =>
+        new cloudwatch.Metric({
+          namespace: NAMESPACE,
+          metricName: "LoginSuccess",
+          dimensionsMap: { Provider: provider },
+          statistic: "Sum",
+          label: provider,
+        }),
+    );
+    dashboard.addWidgets(new cloudwatch.GraphWidget({ title: "Logins", left: loginMetrics, width: 8 }));
+  }
+
   private addApiGatewayAlarms(httpApi: HttpApi) {
-    const dims = { ApiId: httpApi.httpApiId };
-    const period = this.period;
-
-    const requests = new cloudwatch.Metric({
-      namespace: "AWS/ApiGateway",
-      metricName: "Count",
-      dimensionsMap: dims,
-      statistic: "Sum",
-      period,
-    });
-
-    this.addRateAlarm("ApiGateway5xxRate", {
-      errors: new cloudwatch.Metric({
+    const metric = (metricName: string) =>
+      new cloudwatch.Metric({
         namespace: "AWS/ApiGateway",
-        metricName: "5xx",
-        dimensionsMap: dims,
+        metricName,
+        dimensionsMap: { ApiId: httpApi.httpApiId },
         statistic: "Sum",
-        period,
-      }),
-      total: requests,
-      floor: 5,
-      threshold: 10,
-    });
+        period: this.period,
+      });
 
-    this.addRateAlarm("ApiGateway4xxRate", {
-      errors: new cloudwatch.Metric({
-        namespace: "AWS/ApiGateway",
-        metricName: "4xx",
-        dimensionsMap: dims,
-        statistic: "Sum",
-        period,
-      }),
-      total: requests,
-      floor: 10,
-      threshold: 30,
-    });
+    const requests = metric("Count");
+    this.addRateAlarm("ApiGateway5xxRate", { errors: metric("5xx"), total: requests, floor: 5, threshold: 10 });
+    this.addRateAlarm("ApiGateway4xxRate", { errors: metric("4xx"), total: requests, floor: 10, threshold: 30 });
   }
 
   private addLambdaAlarms(lambdas: Function[]) {
-    const period = this.period;
-
     for (const fn of lambdas) {
-      const id = fn.node.scope?.node.id ?? fn.node.id;
-      this.addRateAlarm(`${id}-ErrorRate`, {
-        errors: fn.metricErrors({ statistic: "Sum", period }),
-        total: fn.metricInvocations({ statistic: "Sum", period }),
+      this.addRateAlarm(`${lambdaId(fn)}-ErrorRate`, {
+        errors: fn.metricErrors({ statistic: "Sum", period: this.period }),
+        total: fn.metricInvocations({ statistic: "Sum", period: this.period }),
         floor: 5,
         threshold: 10,
       });
@@ -260,7 +262,6 @@ export class Monitoring extends Construct {
       label: `${id} (%)`,
       period: this.period,
     });
-
     this.addAlarm(id, rate, opts.threshold);
   }
 
@@ -272,7 +273,6 @@ export class Monitoring extends Construct {
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
-
     if (this.alarmAction) alarm.addAlarmAction(this.alarmAction);
     this.alarms.push(alarm);
   }
@@ -282,11 +282,7 @@ export class Monitoring extends Construct {
 
     const denyPolicy = new iam.ManagedPolicy(this, "BudgetDenyPolicy", {
       statements: [
-        new iam.PolicyStatement({
-          effect: iam.Effect.DENY,
-          actions: ["lambda:InvokeFunction"],
-          resources: ["*"],
-        }),
+        new iam.PolicyStatement({ effect: iam.Effect.DENY, actions: ["lambda:InvokeFunction"], resources: ["*"] }),
       ],
     });
 
@@ -327,22 +323,36 @@ export class Monitoring extends Construct {
 
     for (const fn of props.lambdas) {
       if (!fn.role) continue;
-      const id = fn.node.scope?.node.id ?? fn.node.id;
-      new budgets.CfnBudgetsAction(this, `BudgetAction-${id}`, {
+      new budgets.CfnBudgetsAction(this, `BudgetAction-${lambdaId(fn)}`, {
         budgetName: budget.ref,
         notificationType: "ACTUAL",
         actionType: "APPLY_IAM_POLICY",
         actionThreshold: { type: "PERCENTAGE", value: 90 },
         executionRoleArn: budgetRole.roleArn,
         approvalModel: "AUTOMATIC",
-        definition: {
-          iamActionDefinition: {
-            policyArn: denyPolicy.managedPolicyArn,
-            roles: [fn.role.roleName],
-          },
-        },
+        definition: { iamActionDefinition: { policyArn: denyPolicy.managedPolicyArn, roles: [fn.role.roleName] } },
         subscribers: [{ type: "EMAIL", address: props.alarmEmail }],
       });
     }
+  }
+
+  private addBusinessMetrics(props: MonitoringProps) {
+    const metricsLambda = new nodeJsLambda.NodejsFunction(this, "PublishMetricsLambda", {
+      entry: "../lambda/src/handlers/publish-metrics.ts",
+      runtime: lambda.Runtime.NODEJS_22_X,
+      environment: { TABLE_NAMES: props.tables.map((t) => t.tableName).join(",") },
+      timeout: Duration.seconds(30),
+    });
+
+    for (const table of props.tables) {
+      table.grant(metricsLambda, "dynamodb:DescribeTable");
+    }
+
+    metricsLambda.addToRolePolicy(new iam.PolicyStatement({ actions: ["cloudwatch:PutMetricData"], resources: ["*"] }));
+
+    new events.Rule(this, "PublishMetricsSchedule", {
+      schedule: events.Schedule.rate(Duration.hours(6)),
+      targets: [new targets.LambdaFunction(metricsLambda)],
+    });
   }
 }

--- a/packages/infra/lib/constructs/monitoring.ts
+++ b/packages/infra/lib/constructs/monitoring.ts
@@ -3,19 +3,21 @@ import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as sns from "aws-cdk-lib/aws-sns";
 import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
 import * as actions from "aws-cdk-lib/aws-cloudwatch-actions";
-import { Duration } from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as budgets from "aws-cdk-lib/aws-budgets";
+import { Duration, Stack } from "aws-cdk-lib";
 import { HttpApi } from "aws-cdk-lib/aws-apigatewayv2";
-import { IFunction } from "aws-cdk-lib/aws-lambda";
+import { Function } from "aws-cdk-lib/aws-lambda";
 import { ITable } from "aws-cdk-lib/aws-dynamodb";
 import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
 
 export interface MonitoringProps {
   isProd: boolean;
   httpApi: HttpApi;
-  lambdas: IFunction[];
+  lambdas: Function[];
   tables: ITable[];
   deliveryStream: CfnDeliveryStream;
-  alarmEmail?: string;
+  alarmEmail: string;
 }
 
 export class Monitoring extends Construct {
@@ -38,6 +40,7 @@ export class Monitoring extends Construct {
     this.addLambdaAlarms(lambdas);
     this.addDynamoDbAlarms(tables);
     this.addFirehoseAlarms(deliveryStream);
+    this.addCostCircuitBreaker(props);
 
     const dashboard = new cloudwatch.Dashboard(this, "Dashboard", {
       dashboardName: `short-as-${props.isProd ? "prod" : "dev"}`,
@@ -88,7 +91,7 @@ export class Monitoring extends Construct {
     );
   }
 
-  private addLambdaWidgets(dashboard: cloudwatch.Dashboard, lambdas: IFunction[]) {
+  private addLambdaWidgets(dashboard: cloudwatch.Dashboard, lambdas: Function[]) {
     dashboard.addWidgets(new cloudwatch.TextWidget({ markdown: "## Lambda", width: 24, height: 1 }));
 
     const widgets = lambdas.map(
@@ -203,7 +206,7 @@ export class Monitoring extends Construct {
     });
   }
 
-  private addLambdaAlarms(lambdas: IFunction[]) {
+  private addLambdaAlarms(lambdas: Function[]) {
     const period = this.period;
 
     for (const fn of lambdas) {
@@ -272,5 +275,74 @@ export class Monitoring extends Construct {
 
     if (this.alarmAction) alarm.addAlarmAction(this.alarmAction);
     this.alarms.push(alarm);
+  }
+
+  private addCostCircuitBreaker(props: MonitoringProps) {
+    const account = Stack.of(this).account;
+
+    const denyPolicy = new iam.ManagedPolicy(this, "BudgetDenyPolicy", {
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.DENY,
+          actions: ["lambda:InvokeFunction"],
+          resources: ["*"],
+        }),
+      ],
+    });
+
+    const budgetRole = new iam.Role(this, "BudgetActionRole", {
+      assumedBy: new iam.ServicePrincipal("budgets.amazonaws.com"),
+      inlinePolicies: {
+        AttachPolicy: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: ["iam:AttachRolePolicy", "iam:DetachRolePolicy"],
+              resources: [`arn:aws:iam::${account}:role/*`],
+              conditions: { ArnEquals: { "iam:PolicyARN": denyPolicy.managedPolicyArn } },
+            }),
+          ],
+        }),
+      },
+    });
+
+    const budget = new budgets.CfnBudget(this, "MonthlyCostBudget", {
+      budget: {
+        budgetName: "short-as-monthly",
+        budgetType: "COST",
+        timeUnit: "MONTHLY",
+        budgetLimit: { amount: 20, unit: "USD" },
+      },
+      notificationsWithSubscribers: [
+        {
+          notification: {
+            notificationType: "ACTUAL",
+            comparisonOperator: "GREATER_THAN",
+            threshold: 80,
+            thresholdType: "PERCENTAGE",
+          },
+          subscribers: [{ subscriptionType: "EMAIL", address: props.alarmEmail }],
+        },
+      ],
+    });
+
+    for (const fn of props.lambdas) {
+      if (!fn.role) continue;
+      const id = fn.node.scope?.node.id ?? fn.node.id;
+      new budgets.CfnBudgetsAction(this, `BudgetAction-${id}`, {
+        budgetName: budget.ref,
+        notificationType: "ACTUAL",
+        actionType: "APPLY_IAM_POLICY",
+        actionThreshold: { type: "PERCENTAGE", value: 90 },
+        executionRoleArn: budgetRole.roleArn,
+        approvalModel: "AUTOMATIC",
+        definition: {
+          iamActionDefinition: {
+            policyArn: denyPolicy.managedPolicyArn,
+            roles: [fn.role.roleName],
+          },
+        },
+        subscribers: [{ type: "EMAIL", address: props.alarmEmail }],
+      });
+    }
   }
 }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -13,6 +13,7 @@
     "@aws-cdk/aws-glue-alpha": "^2.206.0-alpha.0",
     "@short-as/lambda": "*",
     "@short-as/site": "*",
+    "@short-as/types": "*",
     "aws-cdk-lib": "^2.191.0",
     "cdk-lambda-llrt": "^0.0.15",
     "constructs": "^10.0.0",

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -1100,6 +1100,271 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "MonitoringBudgetActionCreateShortUrlLambdaC9D0510C": {
+      "Properties": {
+        "ActionThreshold": {
+          "Type": "PERCENTAGE",
+          "Value": 90,
+        },
+        "ActionType": "APPLY_IAM_POLICY",
+        "ApprovalModel": "AUTOMATIC",
+        "BudgetName": {
+          "Ref": "MonitoringMonthlyCostBudgetBBEC6E25",
+        },
+        "Definition": {
+          "IamActionDefinition": {
+            "PolicyArn": {
+              "Ref": "MonitoringBudgetDenyPolicy5B5DB152",
+            },
+            "Roles": [
+              {
+                "Ref": "CreateShortUrlLambdaServiceRole05A03927",
+              },
+            ],
+          },
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "MonitoringBudgetActionRole0409EE9B",
+            "Arn",
+          ],
+        },
+        "NotificationType": "ACTUAL",
+        "Subscribers": [
+          {
+            "Address": "ainsley.rutterford@gmail.com",
+            "Type": "EMAIL",
+          },
+        ],
+      },
+      "Type": "AWS::Budgets::BudgetsAction",
+    },
+    "MonitoringBudgetActionGetLongUrlLambda2A874827": {
+      "Properties": {
+        "ActionThreshold": {
+          "Type": "PERCENTAGE",
+          "Value": 90,
+        },
+        "ActionType": "APPLY_IAM_POLICY",
+        "ApprovalModel": "AUTOMATIC",
+        "BudgetName": {
+          "Ref": "MonitoringMonthlyCostBudgetBBEC6E25",
+        },
+        "Definition": {
+          "IamActionDefinition": {
+            "PolicyArn": {
+              "Ref": "MonitoringBudgetDenyPolicy5B5DB152",
+            },
+            "Roles": [
+              {
+                "Ref": "GetLongUrlLambdaServiceRole6B2DF149",
+              },
+            ],
+          },
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "MonitoringBudgetActionRole0409EE9B",
+            "Arn",
+          ],
+        },
+        "NotificationType": "ACTUAL",
+        "Subscribers": [
+          {
+            "Address": "ainsley.rutterford@gmail.com",
+            "Type": "EMAIL",
+          },
+        ],
+      },
+      "Type": "AWS::Budgets::BudgetsAction",
+    },
+    "MonitoringBudgetActionOAuthLambda33135C43": {
+      "Properties": {
+        "ActionThreshold": {
+          "Type": "PERCENTAGE",
+          "Value": 90,
+        },
+        "ActionType": "APPLY_IAM_POLICY",
+        "ApprovalModel": "AUTOMATIC",
+        "BudgetName": {
+          "Ref": "MonitoringMonthlyCostBudgetBBEC6E25",
+        },
+        "Definition": {
+          "IamActionDefinition": {
+            "PolicyArn": {
+              "Ref": "MonitoringBudgetDenyPolicy5B5DB152",
+            },
+            "Roles": [
+              {
+                "Ref": "OAuthLambdaServiceRole36582DA5",
+              },
+            ],
+          },
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "MonitoringBudgetActionRole0409EE9B",
+            "Arn",
+          ],
+        },
+        "NotificationType": "ACTUAL",
+        "Subscribers": [
+          {
+            "Address": "ainsley.rutterford@gmail.com",
+            "Type": "EMAIL",
+          },
+        ],
+      },
+      "Type": "AWS::Budgets::BudgetsAction",
+    },
+    "MonitoringBudgetActionRole0409EE9B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "budgets.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "iam:AttachRolePolicy",
+                    "iam:DetachRolePolicy",
+                  ],
+                  "Condition": {
+                    "ArnEquals": {
+                      "iam:PolicyARN": {
+                        "Ref": "MonitoringBudgetDenyPolicy5B5DB152",
+                      },
+                    },
+                  },
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:aws:iam::",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":role/*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "AttachPolicy",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MonitoringBudgetActionUrlAnalyticsAggregatorE33A9207": {
+      "Properties": {
+        "ActionThreshold": {
+          "Type": "PERCENTAGE",
+          "Value": 90,
+        },
+        "ActionType": "APPLY_IAM_POLICY",
+        "ApprovalModel": "AUTOMATIC",
+        "BudgetName": {
+          "Ref": "MonitoringMonthlyCostBudgetBBEC6E25",
+        },
+        "Definition": {
+          "IamActionDefinition": {
+            "PolicyArn": {
+              "Ref": "MonitoringBudgetDenyPolicy5B5DB152",
+            },
+            "Roles": [
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregatorLambdaServiceRole7CC31995",
+              },
+            ],
+          },
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "MonitoringBudgetActionRole0409EE9B",
+            "Arn",
+          ],
+        },
+        "NotificationType": "ACTUAL",
+        "Subscribers": [
+          {
+            "Address": "ainsley.rutterford@gmail.com",
+            "Type": "EMAIL",
+          },
+        ],
+      },
+      "Type": "AWS::Budgets::BudgetsAction",
+    },
+    "MonitoringBudgetActionUserAPIsLambdaEBD13EB6": {
+      "Properties": {
+        "ActionThreshold": {
+          "Type": "PERCENTAGE",
+          "Value": 90,
+        },
+        "ActionType": "APPLY_IAM_POLICY",
+        "ApprovalModel": "AUTOMATIC",
+        "BudgetName": {
+          "Ref": "MonitoringMonthlyCostBudgetBBEC6E25",
+        },
+        "Definition": {
+          "IamActionDefinition": {
+            "PolicyArn": {
+              "Ref": "MonitoringBudgetDenyPolicy5B5DB152",
+            },
+            "Roles": [
+              {
+                "Ref": "UserAPIsLambdaServiceRoleD33633D8",
+              },
+            ],
+          },
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "MonitoringBudgetActionRole0409EE9B",
+            "Arn",
+          ],
+        },
+        "NotificationType": "ACTUAL",
+        "Subscribers": [
+          {
+            "Address": "ainsley.rutterford@gmail.com",
+            "Type": "EMAIL",
+          },
+        ],
+      },
+      "Type": "AWS::Budgets::BudgetsAction",
+    },
+    "MonitoringBudgetDenyPolicy5B5DB152": {
+      "Properties": {
+        "Description": "",
+        "Path": "/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
     "MonitoringCountBucketsTableThrottled2EB468E5": {
       "Properties": {
         "AlarmActions": [
@@ -1454,7 +1719,59 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
               {
                 "Ref": "UrlAnalyticsAggregatorUrlAnalyticsFirehoseB53E5A44",
               },
-              "",{"stat":"Maximum"}]],"yAxis":{}}}]}",
+              "",{"stat":"Maximum"}]],"yAxis":{}}},{"type":"text","width":24,"height":1,"x":0,"y":43,"properties":{"markdown":"## Business Metrics"}},{"type":"metric","width":8,"height":6,"x":0,"y":44,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UrlsTable60368425",
+              },
+              " Items","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["short.as","ItemCount","TableName","",
+              {
+                "Ref": "UrlsTable60368425",
+              },
+              "",{"stat":"Maximum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":8,"y":44,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "CountBucketsTable09F12BD0",
+              },
+              " Items","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["short.as","ItemCount","TableName","",
+              {
+                "Ref": "CountBucketsTable09F12BD0",
+              },
+              "",{"stat":"Maximum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":16,"y":44,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UsersTable9725E9C8",
+              },
+              " Items","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["short.as","ItemCount","TableName","",
+              {
+                "Ref": "UsersTable9725E9C8",
+              },
+              "",{"stat":"Maximum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":0,"y":50,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+              },
+              " Items","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["short.as","ItemCount","TableName","",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+              },
+              "",{"stat":"Maximum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":0,"y":56,"properties":{"view":"timeSeries","title":"Logins","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["short.as","LoginSuccess","Provider","google",{"label":"google","stat":"Sum"}],["short.as","LoginSuccess","Provider","github",{"label":"github","stat":"Sum"}],["short.as","LoginSuccess","Provider","microsoft",{"label":"microsoft","stat":"Sum"}]],"yAxis":{}}}]}",
             ],
           ],
         },
@@ -1550,6 +1867,36 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "MonitoringMonthlyCostBudgetBBEC6E25": {
+      "Properties": {
+        "Budget": {
+          "BudgetLimit": {
+            "Amount": 20,
+            "Unit": "USD",
+          },
+          "BudgetName": "short-as-monthly",
+          "BudgetType": "COST",
+          "TimeUnit": "MONTHLY",
+        },
+        "NotificationsWithSubscribers": [
+          {
+            "Notification": {
+              "ComparisonOperator": "GREATER_THAN",
+              "NotificationType": "ACTUAL",
+              "Threshold": 80,
+              "ThresholdType": "PERCENTAGE",
+            },
+            "Subscribers": [
+              {
+                "Address": "ainsley.rutterford@gmail.com",
+                "SubscriptionType": "EMAIL",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::Budgets::Budget",
+    },
     "MonitoringOAuthLambdaErrorRateDD33F24C": {
       "Properties": {
         "AlarmActions": [
@@ -1611,6 +1958,207 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringPublishMetricsLambda94D854CB": {
+      "DependsOn": [
+        "MonitoringPublishMetricsLambdaServiceRoleDefaultPolicy427CAE8D",
+        "MonitoringPublishMetricsLambdaServiceRole6DDE0261",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "[S3 KEY]",
+        },
+        "Environment": {
+          "Variables": {
+            "TABLE_NAMES": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "UrlsTable60368425",
+                  },
+                  ",",
+                  {
+                    "Ref": "CountBucketsTable09F12BD0",
+                  },
+                  ",",
+                  {
+                    "Ref": "UsersTable9725E9C8",
+                  },
+                  ",",
+                  {
+                    "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+                  },
+                ],
+              ],
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MonitoringPublishMetricsLambdaServiceRole6DDE0261",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "MonitoringPublishMetricsLambdaServiceRole6DDE0261": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MonitoringPublishMetricsLambdaServiceRoleDefaultPolicy427CAE8D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "dynamodb:DescribeTable",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "UrlsTable60368425",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "UrlsTable60368425",
+                          "Arn",
+                        ],
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "dynamodb:DescribeTable",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "CountBucketsTable09F12BD0",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "dynamodb:DescribeTable",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "UsersTable9725E9C8",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "dynamodb:DescribeTable",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "MonitoringPublishMetricsLambdaServiceRoleDefaultPolicy427CAE8D",
+        "Roles": [
+          {
+            "Ref": "MonitoringPublishMetricsLambdaServiceRole6DDE0261",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "MonitoringPublishMetricsScheduleAllowEventRuleTestBackendStackMonitoringPublishMetricsLambdaF5E5FE7E60C06214": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "MonitoringPublishMetricsLambda94D854CB",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "MonitoringPublishMetricsScheduleBB84B1B6",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "MonitoringPublishMetricsScheduleBB84B1B6": {
+      "Properties": {
+        "ScheduleExpression": "rate(6 hours)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "MonitoringPublishMetricsLambda94D854CB",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "MonitoringUrlAnalyticsAggregationTableThrottled35964981": {
       "Properties": {

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -960,6 +960,860 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
+    "MonitoringAlarmTopicAF62D4F1": {
+      "Properties": {
+        "TopicName": "short-as-alarms",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "MonitoringAlarmTopicainsleyrutterfordgmailcom5CE73936": {
+      "Properties": {
+        "Endpoint": "ainsley.rutterford@gmail.com",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "MonitoringAlarmTopicAF62D4F1",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "MonitoringApiGateway4xxRate4A90DA83": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "IF(total > 10, errors / total * 100, 0)",
+            "Id": "expr_1",
+            "Label": "ApiGateway4xxRate (%)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "total",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiId",
+                    "Value": {
+                      "Ref": "HttpAPI8D545486",
+                    },
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "errors",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiId",
+                    "Value": {
+                      "Ref": "HttpAPI8D545486",
+                    },
+                  },
+                ],
+                "MetricName": "4xx",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 30,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringApiGateway5xxRate097EE0CC": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "IF(total > 5, errors / total * 100, 0)",
+            "Id": "expr_1",
+            "Label": "ApiGateway5xxRate (%)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "total",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiId",
+                    "Value": {
+                      "Ref": "HttpAPI8D545486",
+                    },
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "errors",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiId",
+                    "Value": {
+                      "Ref": "HttpAPI8D545486",
+                    },
+                  },
+                ],
+                "MetricName": "5xx",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringCountBucketsTableThrottled2EB468E5": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": {
+              "Ref": "CountBucketsTable09F12BD0",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRequests",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringCreateShortUrlLambdaErrorRate24549719": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "IF(total > 5, errors / total * 100, 0)",
+            "Id": "expr_1",
+            "Label": "CreateShortUrlLambda-ErrorRate (%)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "total",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "CreateShortUrlLambda8EAB433A",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "errors",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "CreateShortUrlLambda8EAB433A",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringDashboard0C3675C6": {
+      "Properties": {
+        "DashboardBody": {
+          "Fn::Join": [
+            "",
+            [
+              "{"start":"-P14D","widgets":[{"type":"alarm","width":24,"height":3,"x":0,"y":0,"properties":{"title":"Alarm Status","alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringApiGateway5xxRate097EE0CC",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringApiGateway4xxRate4A90DA83",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringCreateShortUrlLambdaErrorRate24549719",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringGetLongUrlLambdaErrorRateB8618C0F",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringOAuthLambdaErrorRateDD33F24C",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringUserAPIsLambdaErrorRateF053EE7B",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringUrlAnalyticsAggregatorErrorRateD8681829",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringUrlsTableThrottled50A33F85",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringCountBucketsTableThrottled2EB468E5",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringUsersTableThrottledE1F355EF",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringUrlAnalyticsAggregationTableThrottled35964981",
+                  "Arn",
+                ],
+              },
+              "","",
+              {
+                "Fn::GetAtt": [
+                  "MonitoringFirehoseFreshnessA545798D",
+                  "Arn",
+                ],
+              },
+              ""]}},{"type":"text","width":24,"height":1,"x":0,"y":3,"properties":{"markdown":"## API Gateway"}},{"type":"metric","width":24,"height":6,"x":0,"y":4,"properties":{"view":"timeSeries","title":"Requests & Errors","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/ApiGateway","Count","ApiId","",
+              {
+                "Ref": "HttpAPI8D545486",
+              },
+              "",{"label":"Requests","stat":"Sum"}],["AWS/ApiGateway","5xx","ApiId","",
+              {
+                "Ref": "HttpAPI8D545486",
+              },
+              "",{"label":"5xx","stat":"Sum"}],["AWS/ApiGateway","4xx","ApiId","",
+              {
+                "Ref": "HttpAPI8D545486",
+              },
+              "",{"label":"4xx","stat":"Sum"}]],"yAxis":{}}},{"type":"text","width":24,"height":1,"x":0,"y":10,"properties":{"markdown":"## Lambda"}},{"type":"metric","width":8,"height":6,"x":0,"y":11,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "CreateShortUrlLambda8EAB433A",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/Lambda","Invocations","FunctionName","",
+              {
+                "Ref": "CreateShortUrlLambda8EAB433A",
+              },
+              "",{"stat":"Sum"}],["AWS/Lambda","Errors","FunctionName","",
+              {
+                "Ref": "CreateShortUrlLambda8EAB433A",
+              },
+              "",{"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":8,"y":11,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "GetLongUrlLambda1C69761E",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/Lambda","Invocations","FunctionName","",
+              {
+                "Ref": "GetLongUrlLambda1C69761E",
+              },
+              "",{"stat":"Sum"}],["AWS/Lambda","Errors","FunctionName","",
+              {
+                "Ref": "GetLongUrlLambda1C69761E",
+              },
+              "",{"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":16,"y":11,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "OAuthLambda5A654FC4",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/Lambda","Invocations","FunctionName","",
+              {
+                "Ref": "OAuthLambda5A654FC4",
+              },
+              "",{"stat":"Sum"}],["AWS/Lambda","Errors","FunctionName","",
+              {
+                "Ref": "OAuthLambda5A654FC4",
+              },
+              "",{"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":0,"y":17,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UserAPIsLambda60578052",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/Lambda","Invocations","FunctionName","",
+              {
+                "Ref": "UserAPIsLambda60578052",
+              },
+              "",{"stat":"Sum"}],["AWS/Lambda","Errors","FunctionName","",
+              {
+                "Ref": "UserAPIsLambda60578052",
+              },
+              "",{"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":8,"y":17,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregatorLambda31B0391A",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/Lambda","Invocations","FunctionName","",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregatorLambda31B0391A",
+              },
+              "",{"stat":"Sum"}],["AWS/Lambda","Errors","FunctionName","",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregatorLambda31B0391A",
+              },
+              "",{"stat":"Sum"}]],"yAxis":{}}},{"type":"text","width":24,"height":1,"x":0,"y":23,"properties":{"markdown":"## DynamoDB"}},{"type":"metric","width":8,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UrlsTable60368425",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/DynamoDB","ThrottledRequests","TableName","",
+              {
+                "Ref": "UrlsTable60368425",
+              },
+              "",{"label":"Throttled","stat":"Sum"}],["AWS/DynamoDB","SystemErrors","TableName","",
+              {
+                "Ref": "UrlsTable60368425",
+              },
+              "",{"label":"System Errors","stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":8,"y":24,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "CountBucketsTable09F12BD0",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/DynamoDB","ThrottledRequests","TableName","",
+              {
+                "Ref": "CountBucketsTable09F12BD0",
+              },
+              "",{"label":"Throttled","stat":"Sum"}],["AWS/DynamoDB","SystemErrors","TableName","",
+              {
+                "Ref": "CountBucketsTable09F12BD0",
+              },
+              "",{"label":"System Errors","stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":16,"y":24,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UsersTable9725E9C8",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/DynamoDB","ThrottledRequests","TableName","",
+              {
+                "Ref": "UsersTable9725E9C8",
+              },
+              "",{"label":"Throttled","stat":"Sum"}],["AWS/DynamoDB","SystemErrors","TableName","",
+              {
+                "Ref": "UsersTable9725E9C8",
+              },
+              "",{"label":"System Errors","stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+              },
+              "","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/DynamoDB","ThrottledRequests","TableName","",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+              },
+              "",{"label":"Throttled","stat":"Sum"}],["AWS/DynamoDB","SystemErrors","TableName","",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+              },
+              "",{"label":"System Errors","stat":"Sum"}]],"yAxis":{}}},{"type":"text","width":24,"height":1,"x":0,"y":36,"properties":{"markdown":"## Firehose"}},{"type":"metric","width":12,"height":6,"x":0,"y":37,"properties":{"view":"timeSeries","title":"Incoming Records","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/Firehose","IncomingRecords","DeliveryStreamName","",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsFirehoseB53E5A44",
+              },
+              "",{"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":12,"height":6,"x":12,"y":37,"properties":{"view":"timeSeries","title":"Delivery Freshness","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/Firehose","DeliveryToS3.DataFreshness","DeliveryStreamName","",
+              {
+                "Ref": "UrlAnalyticsAggregatorUrlAnalyticsFirehoseB53E5A44",
+              },
+              "",{"stat":"Maximum"}]],"yAxis":{}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "short-as-prod",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "MonitoringFirehoseFreshnessA545798D": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "DeliveryStreamName",
+            "Value": {
+              "Ref": "UrlAnalyticsAggregatorUrlAnalyticsFirehoseB53E5A44",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "DeliveryToS3.DataFreshness",
+        "Namespace": "AWS/Firehose",
+        "Period": 900,
+        "Statistic": "Maximum",
+        "Threshold": 900,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringGetLongUrlLambdaErrorRateB8618C0F": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "IF(total > 5, errors / total * 100, 0)",
+            "Id": "expr_1",
+            "Label": "GetLongUrlLambda-ErrorRate (%)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "total",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "GetLongUrlLambda1C69761E",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "errors",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "GetLongUrlLambda1C69761E",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringOAuthLambdaErrorRateDD33F24C": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "IF(total > 5, errors / total * 100, 0)",
+            "Id": "expr_1",
+            "Label": "OAuthLambda-ErrorRate (%)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "total",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "OAuthLambda5A654FC4",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "errors",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "OAuthLambda5A654FC4",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringUrlAnalyticsAggregationTableThrottled35964981": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": {
+              "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregationTable3080F80E",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRequests",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringUrlAnalyticsAggregatorErrorRateD8681829": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "IF(total > 5, errors / total * 100, 0)",
+            "Id": "expr_1",
+            "Label": "UrlAnalyticsAggregator-ErrorRate (%)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "total",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregatorLambda31B0391A",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "errors",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "UrlAnalyticsAggregatorUrlAnalyticsAggregatorLambda31B0391A",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringUrlsTableThrottled50A33F85": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": {
+              "Ref": "UrlsTable60368425",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRequests",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringUserAPIsLambdaErrorRateF053EE7B": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "IF(total > 5, errors / total * 100, 0)",
+            "Id": "expr_1",
+            "Label": "UserAPIsLambda-ErrorRate (%)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "total",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "UserAPIsLambda60578052",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "errors",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "UserAPIsLambda60578052",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringUsersTableThrottledE1F355EF": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MonitoringAlarmTopicAF62D4F1",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": {
+              "Ref": "UsersTable9725E9C8",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRequests",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "OAuthLambda5A654FC4": {
       "DependsOn": [
         "OAuthLambdaServiceRoleDefaultPolicy6729CF8D",

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -22,12 +22,8 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
     "outDir": "./dist",
-    // "typeRoots": [
-    //   "./node_modules/@types"
-    // ]
   },
   "exclude": [
-    // "node_modules",
     "./dist",
     "cdk.out"
   ]

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -20,6 +20,8 @@
     "@aws-sdk/lib-dynamodb": "^3.525.0",
     "@middy/http-error-handler": "^6.3.0",
     "@middy/http-router": "^6.3.1",
+    "@short-as/shared": "*",
+    "@short-as/types": "*",
     "arctic": "^3.7.0",
     "cookie": "^1.0.2",
     "jsrsasign": "^11.1.0",
@@ -30,6 +32,7 @@
     "@types/aws-lambda": "^8.10.149",
     "@types/jest": "^30.0.0",
     "@types/jsrsasign": "^10.5.15",
+    "@types/node": "^24.0.0",
     "esbuild": "^0.27.1",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.6"

--- a/packages/lambda/src/handlers/publish-metrics.ts
+++ b/packages/lambda/src/handlers/publish-metrics.ts
@@ -1,0 +1,25 @@
+import { DescribeTableCommand } from "@aws-sdk/client-dynamodb";
+import { PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+import { dynamoClient } from "../clients/dynamo";
+import { cloudWatchClient } from "../clients/cloudwatch";
+import { getStringEnvironmentVariable } from "../utils";
+
+const TABLE_NAMES = getStringEnvironmentVariable("TABLE_NAMES").split(",");
+
+export const handler = async () => {
+  const metricData = await Promise.all(
+    TABLE_NAMES.map(async (tableName: string) => {
+      const { Table } = await dynamoClient.send(new DescribeTableCommand({ TableName: tableName }));
+      return {
+        MetricName: "ItemCount",
+        Dimensions: [{ Name: "TableName", Value: tableName }],
+        Value: Table?.ItemCount ?? 0,
+        Unit: "Count" as const,
+      };
+    }),
+  );
+
+  await cloudWatchClient.send(new PutMetricDataCommand({ Namespace: "short.as", MetricData: metricData }));
+
+  console.log(`Published item counts for ${TABLE_NAMES.length} tables`);
+};

--- a/packages/lambda/src/metrics.ts
+++ b/packages/lambda/src/metrics.ts
@@ -1,13 +1,29 @@
 import { CloudWatchClient, PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+import { cloudWatchClient } from "./clients/cloudwatch";
 
-const METRIC_NAMESPACE = "short.as";
+const NAMESPACE = "short.as";
+
+export const publishMetric = (metricName: string, value: number, dimensions: Record<string, string> = {}) =>
+  cloudWatchClient.send(
+    new PutMetricDataCommand({
+      Namespace: NAMESPACE,
+      MetricData: [
+        {
+          MetricName: metricName,
+          Dimensions: Object.entries(dimensions).map(([Name, Value]) => ({ Name, Value })),
+          Value: value,
+          Unit: "Count",
+        },
+      ],
+    }),
+  );
 
 export const publishCorruptBucketMetric = (client: CloudWatchClient, countBucketId: number) => {
   console.log(`Publishing corrupt bucket metric for countBucketId: ${countBucketId}`);
   return client.send(
     new PutMetricDataCommand({
       MetricData: [{ MetricName: "CorruptBucketFound", Value: 1 }],
-      Namespace: METRIC_NAMESPACE,
+      Namespace: NAMESPACE,
     }),
   );
 };

--- a/packages/lambda/src/oauth/login/login-handler.ts
+++ b/packages/lambda/src/oauth/login/login-handler.ts
@@ -8,6 +8,7 @@ import { response, siteUrl } from "../../utils";
 import { createOrUpdateUser } from "../user";
 import { UserDdbInput } from "../types";
 import { createLoggedInCookies, TESTING_LOCALHOST } from "../cookies";
+import { publishMetric } from "../../metrics";
 
 export abstract class OAuthLoginHandler {
   protected oAuthProvider: OAuthProvider | undefined;
@@ -38,6 +39,8 @@ export abstract class OAuthLoginHandler {
       const user = await this.fetchUserData(code, cookies.oauth_code_verifier);
       const { id: userId, oAuthProvider, refreshTokenVersion } = await createOrUpdateUser(user);
       const loggedInCookies = await createLoggedInCookies({ now, oAuthProvider, userId, refreshTokenVersion });
+
+      await publishMetric("LoginSuccess", 1, { Provider: oAuthProvider });
 
       return response({ statusCode: 301, cookies: loggedInCookies, headers: { Location: this.loggedInRedirectUrl } });
     } catch (error) {

--- a/packages/lambda/tsconfig.json
+++ b/packages/lambda/tsconfig.json
@@ -1,15 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "paths": {
-      "@short-as/types": ["../types/src/index.ts"],
-      "@short-as/shared": ["../shared/src/index.ts"]
-    },
+    "types": ["node", "jest"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2020",
     "isolatedModules": true
   },
-  "include": ["./src/**/*.ts"],
+  "include": ["./src/**/*.ts", "./test/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@short-as/shared",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -24,6 +24,8 @@
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.0.7",
+    "@short-as/shared": "*",
+    "@short-as/types": "*",
     "@tanstack/react-query": "^5.85.3",
     "@types/mdx": "^2.0.13",
     "@uiw/react-color-colorful": "^2.9.5",

--- a/packages/site/tsconfig.json
+++ b/packages/site/tsconfig.json
@@ -18,9 +18,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@short-as/types": ["../types/src/index.ts"],
-      "@short-as/shared": ["../shared/src/index.ts"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@short-as/types",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}


### PR DESCRIPTION
Part of https://github.com/ainsleyrutterford/short.as/issues/61. This PR adds dashboards and alarms to the backend stack.

The dashboard contains:
- Alarm status widget showing all alarms at a glance
- API Gateway: requests and errors
- Lambda: invocations and errors per function
- DynamoDB: throttled requests and system errors per table
- Firehose: incoming records and delivery freshness
- Business metrics: DynamoDB item counts per table and logins by OAuth provider

The alarms we have:
- API Gateway: 5xx error rate above 10%, 4xx error rate above 30%
- Lambda error rate > 10% per function
- DynamoDB throttled requests > 0
- Firehose delivery freshness > 900s

We have SNS email notifications enabled prod.

**Cost circuit breaker**

- We've set up a $20 per month budget with an 80% email warning
- At 90%, we automatically attach a deny policy to all Lambda execution roles to kill all invocations

**Business metric tracking**

- We've set up a scheduled Lambda that publishes DynamoDB table item counts to CloudWatch
- And a `LoginSuccess` metric with `Provider` as a dimension that is published on each successful OAuth login
