### PR TITLE
Update budget name to include stage

### DIFF
--- a/packages/infra/lib/constructs/monitoring.ts
+++ b/packages/infra/lib/constructs/monitoring.ts
@@ -303,7 +303,7 @@ export class Monitoring extends Construct {
 
     const budget = new budgets.CfnBudget(this, "MonthlyCostBudget", {
       budget: {
-        budgetName: "short-as-monthly",
+        budgetName: `short-as-monthly-${props.isProd ? "prod" : "dev"}`,
         budgetType: "COST",
         timeUnit: "MONTHLY",
         budgetLimit: { amount: 20, unit: "USD" },

--- a/packages/infra/test/__snapshots__/app.test.ts.snap
+++ b/packages/infra/test/__snapshots__/app.test.ts.snap
@@ -1874,7 +1874,7 @@ exports[`Snapshot tests Backend stack matches snapshot 1`] = `
             "Amount": 20,
             "Unit": "USD",
           },
-          "BudgetName": "short-as-monthly",
+          "BudgetName": "short-as-monthly-prod",
           "BudgetType": "COST",
           "TimeUnit": "MONTHLY",
         },


### PR DESCRIPTION
Part of https://github.com/ainsleyrutterford/short.as/issues/61.

https://github.com/ainsleyrutterford/short.as/pull/86 wouldn't deploy to prod since we didn't include the stage in the budget name so it tried to deploy the same budget twice for dev and prod. This PR should fix that.